### PR TITLE
Bump of pydantic version and minor fix of basic usage readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Basic Usage
 
 The Alita SDK allows you to create and execute agents with ease. Here's a simple example to get you started:
 
+```bash
+pip install alita-sdk
+```
 
 ```python
 import logging
@@ -89,13 +92,16 @@ settings = {
     
 }
 
+agent_id = 1  # Created Agent ID in Alita Platform
+agent_version_id = 1
+
 print(settings)
 if 'messages' not in st.session_state:
     llm = AlitaChatModel(**settings)
     st.session_state.messages = []
-    st.session_state.agent_executor = llm.client.application(llm, <application_id>, <application_version_id>)
-    
- 
+    st.session_state.agent_executor = llm.client.application(llm, agent_id, agent_version_id)
+
+
 run_streamlit(st)
 
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ alita_tools>=0.0.44
 jinja2~=3.1.3
 pillow~=10.2.0
 requests~=2.31.0
-pydantic~=1.10.9
+pydantic~=1.10.17
 chardet==5.2.0


### PR DESCRIPTION
1. Pydantic version was bumped due to an unsupported way of evaluating Type in langchain_core.callbacks
`TypeError: ForwardRef._evaluate() missing 1 required keyword-only argument: 'recursive_guard'`
2. Basic usage in readme.md was updated to clarify needed variables to initialize Agent and added alita_sdk installation step to allow the use of SDK in external projects