### PR TITLE
Add RouterNode and simplify router-based conditional routing

### DIFF
--- a/src/alita_sdk/langchain/utils.py
+++ b/src/alita_sdk/langchain/utils.py
@@ -128,7 +128,7 @@ def parse_type(type_str):
 
 
 def create_state(data: Optional[dict] = None):
-    state_dict = {'input': str,}
+    state_dict = {'input': str, 'router_output': str}  # Always include router_output
     if not data:
         data = {'messages': 'list[str]'}
     for key, value in data.items():

--- a/src/alita_sdk/tools/router.py
+++ b/src/alita_sdk/tools/router.py
@@ -23,7 +23,9 @@ class RouterNode(BaseTool):
         result = template.evaluate()
         logger.info(f"RouterNode evaluated condition '{self.condition}' with input {input_data} => {result}")
         result = clean_string(str(result))
-        if result in [clean_string(r) for r in self.routes]:
+        if self._cleaned_routes is None:
+            self._cleaned_routes = [clean_string(r) for r in self.routes]
+        if result in self._cleaned_routes:
             return {"router_output": result}
         return {"router_output": clean_string(self.default_output)}
 

--- a/src/alita_sdk/tools/router.py
+++ b/src/alita_sdk/tools/router.py
@@ -23,11 +23,13 @@ class RouterNode(BaseTool):
         result = template.evaluate()
         logger.info(f"RouterNode evaluated condition '{self.condition}' with input {input_data} => {result}")
         result = clean_string(str(result))
-        if self._cleaned_routes is None:
-            self._cleaned_routes = [clean_string(r) for r in self.routes]
-        if result in self._cleaned_routes:
+        if result in self.routes:
+            # If the result is one of the routes, return it
             return {"router_output": result}
-        return {"router_output": clean_string(self.default_output)}
+        elif result == self.default_output:
+            # If the result is the default output, return it
+            return {"router_output": clean_string(self.default_output)}
+        return {"router_output": 'END'}
 
     def _run(self, *args, **kwargs):
         return self.invoke(**kwargs)

--- a/src/alita_sdk/tools/router.py
+++ b/src/alita_sdk/tools/router.py
@@ -1,0 +1,31 @@
+import logging
+from typing import Any, Optional, Union, List
+from langchain_core.runnables import RunnableConfig
+from langchain_core.tools import BaseTool
+from ..utils.evaluate import EvaluateTemplate
+from ..utils.utils import clean_string
+
+logger = logging.getLogger(__name__)
+
+class RouterNode(BaseTool):
+    name: str = 'RouterNode'
+    description: str = 'A router node that evaluates a condition and routes accordingly.'
+    condition: str = ''
+    routes: List[str] = []  # List of possible output node keys
+    default_output: str = 'END'
+    input_variables: Optional[list[str]] = None
+
+    def invoke(self, state: Union[str, dict], config: Optional[RunnableConfig] = None, **kwargs: Any) -> dict:
+        input_data = {}
+        for field in self.input_variables or []:
+            input_data[field] = state.get(field, "")
+        template = EvaluateTemplate(self.condition, input_data)
+        result = template.evaluate()
+        logger.info(f"RouterNode evaluated condition '{self.condition}' with input {input_data} => {result}")
+        result = clean_string(str(result))
+        if result in [clean_string(r) for r in self.routes]:
+            return {"router_output": result}
+        return {"router_output": clean_string(self.default_output)}
+
+    def _run(self, *args, **kwargs):
+        return self.invoke(**kwargs)


### PR DESCRIPTION
- Add RouterNode for independent conditional routing in pipelines
- Always include router_output in agent state
- Simplify router edge logic to use a single ConditionalEdge
- Remove duplicate create_state

Closes #<original-issue-number> (please update with actual issue number if needed)