### PR TITLE
Fix message parsing in predict

### DIFF
--- a/src/alita_sdk/clients/client.py
+++ b/src/alita_sdk/clients/client.py
@@ -348,7 +348,7 @@ class AlitaClient:
             response_data = response.json()
             response_messages = []
             for message in response_data['messages']:
-                if message.get('type') == 'user':
+                if message.get('role') == 'user':
                     response_messages.append(HumanMessage(content=message['content']))
                 else:
                     response_messages.append(AIMessage(content=message['content']))


### PR DESCRIPTION
## Summary
- fix message role key in `AlitaClient.predict`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alita_tools')*

------
https://chatgpt.com/codex/tasks/task_e_683fed4a8f308326bc84cf3512e3dbf8