### PR TITLE
Fix typo in pyproject description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "alita_sdk"
 version = "0.3.128"
-description = "SDK for building langchain agents using resouces from Alita"
+description = "SDK for building langchain agents using resources from Alita"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [ "Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent",]


### PR DESCRIPTION
## Summary
- correct typo in project description

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*


------
https://chatgpt.com/codex/tasks/task_e_683ff0e9fac08326a0a2ca5b50c35b5f