### PR TITLE
Fix typos in tool docstrings

### DIFF
--- a/src/alita_sdk/tools/loop_output.py
+++ b/src/alita_sdk/tools/loop_output.py
@@ -39,8 +39,8 @@ Tool arguments schema:
 """
     unstructured_output: str = """Expected output is JSON that to be used as a KWARGS for the tool call like {{"key": "value"}} 
 in case your key is "chat_history" value should be a list of messages with roles like {{"chat_history": [{{"role": "user", "content": "input"}}, {{"role": "assistant", "content": "output"}}]}}.
-Tool won't have access to convesation so all keys and values need to be actual and independant. 
-Anwer must be JSON only extractable by JSON.LOADS."""
+Tool won't have access to conversation so all keys and values need to be actual and independent.
+Answer must be JSON only extractable by JSON.LOADS."""
 
     def invoke(
             self,

--- a/src/alita_sdk/tools/tool.py
+++ b/src/alita_sdk/tools/tool.py
@@ -37,8 +37,8 @@ Tool arguments schema:
 """
     unstructured_output: str = """Expected output is JSON that to be used as a KWARGS for the tool call like {{"key": "value"}} 
 in case your key is "chat_history" value should be a list of messages with roles like {{"chat_history": [{{"role": "user", "content": "input"}}, {{"role": "assistant", "content": "output"}}]}}.
-Tool won't have access to convesation so all keys and values need to be actual and independant. 
-Anwer must be JSON only extractable by JSON.LOADS."""
+Tool won't have access to conversation so all keys and values need to be actual and independent.
+Answer must be JSON only extractable by JSON.LOADS."""
 
     def invoke(
             self,


### PR DESCRIPTION
## Summary
- correct 'conversation', 'independent' and 'Answer' typos

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'alita_tools')*

------
https://chatgpt.com/codex/tasks/task_e_683ff10da31883269368bc3211f8dc1b