### PR TITLE
Feat/update carrier toolkit UI

### DIFF
--- a/alita_sdk/tools/carrier/api_wrapper.py
+++ b/alita_sdk/tools/carrier/api_wrapper.py
@@ -138,6 +138,10 @@ class CarrierAPIWrapper(BaseModel):
         """Get detailed UI test configuration by test ID."""
         return self._client.get_ui_test_details(test_id)
 
+    def create_ui_test(self, json_body: Dict[str, Any]) -> Dict[str, Any]:
+        """Create a new UI test."""
+        return self._client.create_ui_test(json_body)
+
     def get_ui_report_json_files(self, uid: str) -> list:
         """Get all JSON file names for a given UI report UID for Excel processing."""
         endpoint = f"api/v1/ui_performance/results/{self.project_id}/{uid}?sort=loop&order=asc"

--- a/alita_sdk/tools/carrier/api_wrapper.py
+++ b/alita_sdk/tools/carrier/api_wrapper.py
@@ -142,6 +142,10 @@ class CarrierAPIWrapper(BaseModel):
         """Create a new UI test."""
         return self._client.create_ui_test(json_body)
 
+    def cancel_ui_test(self, test_id: str) -> Dict[str, Any]:
+        """Cancel a UI test by setting its status to Canceled."""
+        return self._client.cancel_ui_test(test_id)
+
     def get_ui_report_json_files(self, uid: str) -> list:
         """Get all JSON file names for a given UI report UID for Excel processing."""
         endpoint = f"api/v1/ui_performance/results/{self.project_id}/{uid}?sort=loop&order=asc"

--- a/alita_sdk/tools/carrier/api_wrapper.py
+++ b/alita_sdk/tools/carrier/api_wrapper.py
@@ -129,3 +129,11 @@ class CarrierAPIWrapper(BaseModel):
         except Exception as e:
             logger.error(f"Failed to fetch UI report links: {e}")
             return []
+
+    def update_ui_test(self, test_id: str, json_body) -> Dict[str, Any]:
+        """Update UI test configuration and schedule."""
+        return self._client.update_ui_test(test_id, json_body)
+
+    def get_ui_test_details(self, test_id: str) -> Dict[str, Any]:
+        """Get detailed UI test configuration by test ID."""
+        return self._client.get_ui_test_details(test_id)

--- a/alita_sdk/tools/carrier/api_wrapper.py
+++ b/alita_sdk/tools/carrier/api_wrapper.py
@@ -85,11 +85,15 @@ class CarrierAPIWrapper(BaseModel):
 
     def get_ui_reports_list(self) -> List[Dict[str, Any]]:
         """Get list of UI test reports from the Carrier platform."""
-        return self._client.get_ui_tests_list()
+        return self._client.get_ui_reports_list()
 
     def get_ui_tests_list(self) -> List[Dict[str, Any]]:
         """Get list of UI tests from the Carrier platform."""
         return self._client.get_ui_tests_list()
+
+    def get_locations(self) -> Dict[str, Any]:
+        """Get list of available locations/cloud settings from the Carrier platform."""
+        return self._client.get_locations()
 
     def get_ui_report_links(self, uid: str) -> list:
         """Get all unique file_names for a given UI report UID, ending with .html, without #index=*, and only unique values."""

--- a/alita_sdk/tools/carrier/api_wrapper.py
+++ b/alita_sdk/tools/carrier/api_wrapper.py
@@ -67,6 +67,10 @@ class CarrierAPIWrapper(BaseModel):
     def run_test(self, test_id: str, json_body):
         return self._client.run_test(test_id, json_body)
 
+    def run_ui_test(self, test_id: str, json_body):
+        """Run a UI test with the given test ID and JSON body."""
+        return self._client.run_ui_test(test_id, json_body)
+
     def get_engagements_list(self) -> List[Dict[str, Any]]:
         return self._client.get_engagements_list()
 

--- a/alita_sdk/tools/carrier/cancel_ui_test_tool.py
+++ b/alita_sdk/tools/carrier/cancel_ui_test_tool.py
@@ -1,0 +1,178 @@
+import logging
+import re
+import traceback
+from typing import Type
+from langchain_core.tools import BaseTool, ToolException
+from pydantic.fields import Field
+from pydantic import create_model, BaseModel
+from .api_wrapper import CarrierAPIWrapper
+
+logger = logging.getLogger(__name__)
+
+
+class CancelUITestTool(BaseTool):
+    api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
+    name: str = "cancel_ui_test"
+    description: str = "Cancel a UI test or show available tests to cancel in the Carrier platform."
+    args_schema: Type[BaseModel] = create_model(
+        "CancelUITestInput",
+        **{
+            "message": (str, Field(description="User input message (e.g., 'Cancel UI test' or 'Cancel UI test 12345')")),
+        }
+    )
+
+    def _run(self, message: str):
+        try:
+            # Parse the message to extract test ID if provided
+            test_id = self._extract_test_id(message)
+            
+            if test_id:
+                # User provided a specific test ID to cancel
+                return self._cancel_specific_test(test_id)
+            else:
+                # User didn't provide ID, show available tests to cancel
+                return self._show_cancelable_tests()
+                
+        except Exception as e:
+            logger.error(f"Error in cancel UI test: {e}")
+            raise ToolException(f"Failed to process cancel UI test request: {str(e)}")
+
+    def _extract_test_id(self, message: str) -> str:
+        """Extract test ID from user message if present."""
+        # Look for patterns like "Cancel UI test 12345" or "cancel ui test 12345"
+        match = re.search(r'cancel\s+ui\s+test\s+(\d+)', message.lower())
+        if match:
+            return match.group(1)
+        return ""
+
+    def _show_cancelable_tests(self) -> str:
+        """Show list of tests that can be canceled."""
+        try:
+            # Get all UI reports/tests
+            reports = self.api_wrapper.get_ui_reports_list()
+            
+            if not reports:
+                return "❌ **No UI tests found.**"
+            
+            # Filter tests that can be canceled (not in final states)
+            final_states = {"Canceled", "Finished", "Failed"}
+            cancelable_tests = []
+            
+            for report in reports:
+                test_status = report.get("test_status", {})
+                status = test_status.get("status", "Unknown")
+                
+                # Check if status is not in final states
+                if status not in final_states:
+                    cancelable_tests.append({
+                        "id": report.get("id"),
+                        "name": report.get("name", "Unknown"),
+                        "status": status,
+                        "percentage": test_status.get("percentage", 0),
+                        "description": test_status.get("description", "")
+                    })
+            
+            if not cancelable_tests:
+                return """# ℹ️ No Tests Available for Cancellation
+
+All UI tests are already in final states (Canceled, Finished, or Failed).
+
+## 🔍 To cancel a specific test:
+Use the command: `Cancel UI test <test_id>`
+
+Example: `Cancel UI test 12345`"""
+            
+            # Build the response message
+            response = """# 🚫 UI Tests Available for Cancellation
+
+The following tests are currently running and can be canceled:
+
+## 📋 Active Tests:
+"""
+            
+            for test in cancelable_tests:
+                response += f"""
+### 🔸 Test ID: `{test['id']}`
+- **Name:** `{test['name']}`
+- **Status:** `{test['status']}`
+- **Progress:** {test['percentage']}%
+- **Description:** {test['description']}
+"""
+            
+            response += """
+## 🚫 To cancel a specific test:
+Use the command: `Cancel UI test <test_id>`
+
+Example: `Cancel UI test 12345`"""
+            
+            return response
+            
+        except Exception as e:
+            logger.error(f"Error fetching cancelable tests: {e}")
+            return f"❌ **Error fetching tests:** {str(e)}"
+
+    def _cancel_specific_test(self, test_id: str) -> str:
+        """Cancel a specific UI test by ID."""
+        try:
+            # First, get the current status of the test
+            reports = self.api_wrapper.get_ui_reports_list()
+            target_test = None
+            
+            for report in reports:
+                if str(report.get("id")) == test_id:
+                    target_test = report
+                    break
+            
+            if not target_test:
+                return f"❌ **Test with ID `{test_id}` not found.**"
+            
+            # Check if test can be canceled
+            test_status = target_test.get("test_status", {})
+            current_status = test_status.get("status", "Unknown")
+            final_states = {"Canceled", "Finished", "Failed"}
+            
+            if current_status in final_states:
+                return f"""# ❌ Cannot Cancel Test
+
+## Test Information:
+- **Test ID:** `{test_id}`
+- **Name:** `{target_test.get('name', 'Unknown')}`
+- **Current Status:** `{current_status}`
+
+## 🚫 Reason:
+This test cannot be canceled because it is already in a final state (`{current_status}`).
+
+Only tests with status **not** in `Canceled`, `Finished`, or `Failed` can be canceled."""
+            
+            # Attempt to cancel the test
+            try:
+                cancel_response = self.api_wrapper.cancel_ui_test(test_id)
+                
+                return f"""# ✅ UI Test Canceled Successfully!
+
+## Test Information:
+- **Test ID:** `{test_id}`
+- **Name:** `{target_test.get('name', 'Unknown')}`
+- **Previous Status:** `{current_status}`
+- **New Status:** `Canceled`
+
+## 🎯 Result:
+The test has been successfully canceled and will stop executing."""
+                
+            except Exception as cancel_error:
+                logger.error(f"Error canceling test {test_id}: {cancel_error}")
+                return f"""# ❌ Failed to Cancel Test
+
+## Test Information:
+- **Test ID:** `{test_id}`
+- **Name:** `{target_test.get('name', 'Unknown')}`
+- **Current Status:** `{current_status}`
+
+## 🚫 Error:
+{str(cancel_error)}
+
+Please check the test ID and try again."""
+                
+        except Exception as e:
+            logger.error(f"Error canceling specific test {test_id}: {e}")
+            return f"❌ **Error processing cancellation for test `{test_id}`: {str(e)}**"

--- a/alita_sdk/tools/carrier/carrier_sdk.py
+++ b/alita_sdk/tools/carrier/carrier_sdk.py
@@ -85,6 +85,11 @@ class CarrierClient(BaseModel):
         endpoint = f"api/v1/backend_performance/test/{self.credentials.project_id}/{test_id}"
         return self.request('post', endpoint, json=json_body).get("result_id", "")
 
+    def run_ui_test(self, test_id: str, json_body):
+        """Run a UI test with the given test ID and JSON body."""
+        endpoint = f"api/v1/ui_performance/test/{self.credentials.project_id}/{test_id}"
+        return self.request('post', endpoint, json=json_body).get("result_id", "")
+
     def get_engagements_list(self) -> List[Dict[str, Any]]:
         endpoint = f"api/v1/engagements/engagements/{self.credentials.project_id}"
         return self.request('get', endpoint).get("items", [])

--- a/alita_sdk/tools/carrier/carrier_sdk.py
+++ b/alita_sdk/tools/carrier/carrier_sdk.py
@@ -217,3 +217,13 @@ class CarrierClient(BaseModel):
         """Get list of available locations/cloud settings from the Carrier platform."""
         endpoint = f"api/v1/shared/locations/{self.credentials.project_id}"
         return self.request('get', endpoint)
+
+    def update_ui_test(self, test_id: str, json_body) -> Dict[str, Any]:
+        """Update UI test configuration and schedule."""
+        endpoint = f"api/v1/ui_performance/test/{self.credentials.project_id}/{test_id}"
+        return self.request('put', endpoint, json=json_body)
+
+    def get_ui_test_details(self, test_id: str) -> Dict[str, Any]:
+        """Get detailed UI test configuration by test ID."""
+        endpoint = f"api/v1/ui_performance/test/{self.credentials.project_id}/{test_id}"
+        return self.request('get', endpoint)

--- a/alita_sdk/tools/carrier/carrier_sdk.py
+++ b/alita_sdk/tools/carrier/carrier_sdk.py
@@ -212,3 +212,8 @@ class CarrierClient(BaseModel):
             """Get list of UI test reports from the Carrier platform."""
             endpoint = f"api/v1/ui_performance/reports/{self.credentials.project_id}"
             return self.request('get', endpoint).get("rows", [])
+
+    def get_locations(self) -> Dict[str, Any]:
+        """Get list of available locations/cloud settings from the Carrier platform."""
+        endpoint = f"api/v1/shared/locations/{self.credentials.project_id}"
+        return self.request('get', endpoint)

--- a/alita_sdk/tools/carrier/carrier_sdk.py
+++ b/alita_sdk/tools/carrier/carrier_sdk.py
@@ -261,3 +261,17 @@ class CarrierClient(BaseModel):
         finally:
             # Restore original headers
             self.session.headers.update(original_headers)
+
+    def cancel_ui_test(self, test_id: str) -> Dict[str, Any]:
+        """Cancel a UI test by setting its status to Canceled."""
+        endpoint = f"api/v1/ui_performance/report_status/{self.credentials.project_id}/{test_id}"
+        
+        cancel_body = {
+            "test_status": {
+                "status": "Canceled",
+                "percentage": 100,
+                "description": "Test was canceled"
+            }
+        }
+        
+        return self.request('put', endpoint, json=cancel_body)

--- a/alita_sdk/tools/carrier/create_ui_excel_report_tool.py
+++ b/alita_sdk/tools/carrier/create_ui_excel_report_tool.py
@@ -1,0 +1,464 @@
+import logging
+import json
+import traceback
+import tempfile
+import os
+from datetime import datetime
+from typing import Type
+from langchain_core.tools import BaseTool, ToolException
+from pydantic.fields import Field
+from pydantic import create_model, BaseModel
+from .api_wrapper import CarrierAPIWrapper
+
+
+logger = logging.getLogger(__name__)
+
+
+class CreateUIExcelReportTool(BaseTool):
+    api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
+    name: str = "create_excel_report_ui"
+    description: str = "Create Excel report from UI test results JSON files from the Carrier platform."
+    args_schema: Type[BaseModel] = create_model(
+        "CreateUIExcelReportInput",
+        report_id=(str, Field(default="", description="UI Report ID to generate Excel report for")),
+    )
+    def _run(self, report_id: str = ""):
+        try:
+            # Check if report_id is provided
+            if not report_id or report_id.strip() == "":
+                return self._missing_input_response()
+            
+            # Get UI reports list and find the specific report
+            ui_reports = self.api_wrapper.get_ui_reports_list()
+            
+            # Find the report by ID
+            target_report = None
+            for report in ui_reports:
+                if str(report.get("id")) == str(report_id):
+                    target_report = report
+                    break
+            
+            if not target_report:
+                return self._show_available_reports_message()
+            
+            return self._process_ui_report(target_report, report_id)
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error creating UI Excel report: {stacktrace}")
+            raise ToolException(stacktrace)
+    def _missing_input_response(self):
+        """Response when report_id is missing."""
+        return "Please provide me test id for generating excel report from your UI test"
+    
+    def _show_available_reports_message(self):
+        """Show available reports when no matching report_id found."""
+        try:
+            ui_reports = self.api_wrapper.get_ui_reports_list()
+            
+            if not ui_reports:
+                return "❌ **No UI test reports found.**"
+            
+            message = ["# ❌ No report found for the specified report ID\n"]
+            message.append("## Available Report IDs:")
+            
+            for report in ui_reports[:10]:  # Show first 10 reports
+                report_id = report.get("id")
+                report_name = report.get("name", "Unnamed Report")
+                test_status = report.get("test_status", "Unknown")
+                start_time = report.get("start_time", "")
+                
+                message.append(f"- **Report ID: {report_id}** - {report_name} ({test_status}) - {start_time}")
+            
+            if len(ui_reports) > 10:
+                message.append(f"... and {len(ui_reports) - 10} more reports")
+            
+            message.append("\n## 💡 Example:")
+            message.append("```")
+            message.append(f"report_id: {ui_reports[0].get('id') if ui_reports else 'YOUR_REPORT_ID'}")
+            message.append("```")
+            return "\n".join(message)
+            
+        except Exception:
+            return "❌ **Error retrieving available report IDs. Please check your report_id and try again.**"
+    
+    def _process_ui_report(self, report, report_id):
+        """Process single UI report and generate Excel file."""
+        try:            # Get the UID from the report (similar to get_ui_report_by_id logic)
+            uid = report.get("uid")
+            if not uid:
+                return f"❌ **No UID found for report {report_id}. Cannot process this report.**"
+            
+            # Create Excel reporter instance
+            current_date = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+            excel_file_name = f'/tmp/ui_report_{report_id}_{current_date}.xlsx'
+            
+            excel_reporter = LighthouseExcelReporter(excel_file_name)
+            
+            processed_files = 0
+            
+            # Get report links using the same method as GetUIReportByIDTool
+            report_links = self.api_wrapper.get_ui_report_links(uid)
+            
+            if not report_links:
+                return f"❌ **No report links found for report {report_id}.**"
+            
+            # Process each report link by converting HTML to JSON
+            for html_url in report_links:
+                try:
+                    # Convert HTML URL to JSON URL by replacing .html with .json
+                    json_url = html_url.replace('.html', '.json')
+                    
+                    # Extract file name from URL for worksheet naming
+                    json_file_name = json_url.split('/')[-1]
+                    
+                    # Download JSON content directly from the converted URL
+                    # Extract bucket and file name from the URL structure
+                    # URL format: https://platform.getcarrier.io/api/v1/artifacts/artifact/default/{project_id}/reports/{file_name}
+                    url_parts = json_url.split('/')
+                    if len(url_parts) >= 2:
+                        bucket = url_parts[-2]  # "reports"
+                        file_name = url_parts[-1]  # actual file name
+                    else:
+                        bucket = "reports"
+                        file_name = json_file_name
+                    
+                    json_content = self.api_wrapper.download_ui_report_json(bucket, file_name)
+                    
+                    if json_content:
+                        # Create worksheet name from JSON file name
+                        worksheet_name = self._create_worksheet_name(json_file_name)
+                        
+                        # Process JSON and add to Excel
+                        excel_reporter.add_json_report(json_content, worksheet_name)
+                        processed_files += 1
+                        
+                except Exception as e:
+                    logger.error(f"Error processing JSON file from {html_url}: {e}")
+                    continue
+            
+            if processed_files == 0:
+                return f"❌ **No JSON files could be processed for report {report_id}.**"
+            
+            # Finalize Excel file
+            excel_reporter.finalize()
+            
+            # Upload to Carrier artifacts
+            report_name = report.get("name", f"report_{report_id}")
+            bucket_name = report_name.replace("_", "").replace(" ", "").lower()
+            excel_file_basename = os.path.basename(excel_file_name)
+            
+            self.api_wrapper.upload_excel_report(bucket_name, excel_file_name)
+            
+            # Clean up temporary file
+            if os.path.exists(excel_file_name):
+                os.remove(excel_file_name)
+            
+            download_link = f"{self.api_wrapper.url.rstrip('/')}/api/v1/artifacts/artifact/default/{self.api_wrapper.project_id}/{bucket_name}/{excel_file_basename}"
+            
+            return f"""# ✅ UI Excel Report Generated Successfully!
+
+## Report Information:
+- **Report ID:** `{report_id}`
+- **Report Name:** `{report.get("name", "N/A")}`
+- **JSON Files Processed:** `{processed_files}`
+- **Excel File:** `{excel_file_basename}`
+- **Bucket:** `{bucket_name}`
+
+## 📥 Download Link:
+[Download Excel Report]({download_link})
+
+## 🎯 What's included:
+- Multiple worksheets for each JSON report file
+- Lighthouse performance metrics formatted for analysis
+- Conditional formatting for easy identification of performance issues"""
+            
+        except Exception as e:
+            logger.error(f"Error processing UI report: {e}")
+            raise ToolException(f"Error processing UI report: {e}")
+    
+    def _create_worksheet_name(self, json_file_name):
+        """Create a valid worksheet name from JSON file name."""
+        # Remove .json extension
+        name = json_file_name.replace('.json', '')
+        
+        # Replace : with _ as specified in requirements
+        name = name.replace(':', '_')
+        
+        # Excel worksheet names have limitations
+        # Max 31 characters, no special characters except underscore
+        name = name.replace('/', '_').replace('\\', '_').replace('[', '_').replace(']', '_')
+        name = name.replace('*', '_').replace('?', '_').replace(':', '_')
+        
+        # Truncate if too long
+        if len(name) > 31:
+            name = name[:31]
+        
+        return name
+
+
+class LighthouseExcelReporter:
+    """Excel reporter for Lighthouse UI test results."""
+    
+    def __init__(self, output_file):
+        """Initialize the Excel reporter."""
+        self.output_file = output_file
+        self.workbook = None
+        self.worksheets = {}
+        
+        # Import required libraries
+        try:
+            import pandas as pd
+            from openpyxl import Workbook
+            from openpyxl.styles import Alignment, PatternFill, Border, Side
+            from openpyxl.formatting.rule import CellIsRule
+            from openpyxl.utils import get_column_letter
+            
+            self.pd = pd
+            self.Workbook = Workbook
+            self.Alignment = Alignment
+            self.PatternFill = PatternFill
+            self.Border = Border
+            self.Side = Side
+            self.CellIsRule = CellIsRule
+            self.get_column_letter = get_column_letter
+            
+            self.workbook = Workbook()
+            # Remove default sheet
+            if self.workbook.worksheets:
+                self.workbook.remove(self.workbook.active)
+                
+        except ImportError as e:
+            raise ToolException(f"Required libraries not available: {e}")
+    
+    def add_json_report(self, json_content, worksheet_name):
+        """Add a JSON report as a new worksheet."""
+        try:
+            # Parse JSON content
+            if isinstance(json_content, str):
+                data = json.loads(json_content)
+            else:
+                data = json_content
+            
+            # Process Lighthouse data similar to the reference file
+            data_rows = self._process_lighthouse_data(data)
+            
+            if not data_rows:
+                logger.warning(f"No data extracted from JSON for worksheet {worksheet_name}")
+                return
+            
+            # Create DataFrame
+            df = self.pd.DataFrame(data_rows)
+            
+            if df.empty:
+                logger.warning(f"Empty DataFrame for worksheet {worksheet_name}")
+                return
+            
+            # Create pivot table
+            df_pivot = df.pivot_table(index="Step name", columns="Audit", values="Numeric Value", aggfunc='mean')
+            df_pivot = df_pivot.fillna('')
+            
+            # Add worksheet
+            ws = self.workbook.create_sheet(title=worksheet_name)
+            
+            # Write data to worksheet
+            self._write_dataframe_to_worksheet(df_pivot, ws)
+            
+            # Apply formatting
+            self._apply_formatting(ws, df_pivot)
+            
+            logger.info(f"Added worksheet: {worksheet_name}")
+            
+        except Exception as e:
+            logger.error(f"Error processing JSON report for worksheet {worksheet_name}: {e}")
+    
+    def _process_lighthouse_data(self, data):
+        """Process Lighthouse JSON data similar to the reference implementation."""
+        from urllib.parse import urlparse
+        from collections import OrderedDict
+        import re
+        
+        # Performance audits to extract (from reference file)
+        performance_audits = [
+            'first-contentful-paint',
+            'speed-index',
+            'interactive',
+            'total-blocking-time',
+            'largest-contentful-paint',
+            'cumulative-layout-shift',
+            'network-requests',
+            'bootup-time',
+            'interaction-to-next-paint',
+            'server-response-time',
+        ]
+        
+        # Audit naming mappings (from reference file)
+        sec_audits = ['first-contentful-paint', 'interactive', 'largest-contentful-paint', 'mainthread-work-breakdown', 'network-requests', 'speed-index', 'javaScript-execution-time']
+        ms_audits = ['interaction-to-next-paint', 'total-blocking-time', 'time-to-first-byte']
+        
+        rename_audits = {
+            'bootup-time': 'javaScript-execution-time',
+            'server-response-time': 'time-to-first-byte'
+        }
+        
+        def extract_application_name(url):
+            parsed_url = urlparse(url)
+            hostname_parts = parsed_url.hostname.split('.') if parsed_url.hostname else []
+            application_name = hostname_parts[0] if len(hostname_parts) > 1 else '3rd-party'
+            return application_name
+        
+        data_rows = []
+        step_order = OrderedDict()
+        
+        # Process steps from the data
+        steps = data.get('steps', [])
+        if not steps:
+            # If no steps, treat the entire data as a single step
+            steps = [{'name': 'main_report', 'lhr': data}]
+        
+        for index, step in enumerate(steps):
+            step_name = step.get('name', f'step_{index}')
+            step_order[step_name] = index
+            lhr_data = step.get('lhr', {})
+            
+            url = lhr_data.get('finalDisplayedUrl', '3rd-party')
+            application_name = extract_application_name(url)
+            
+            performance_score = lhr_data.get('categories', {}).get('performance', {}).get('score')
+            performance_score = performance_score * 100 if performance_score is not None else None
+            
+            for audit in performance_audits:
+                audit_result = lhr_data.get('audits', {}).get(audit, {})
+                numeric_value = audit_result.get('displayValue')
+                
+                if numeric_value is not None:
+                    numeric_value = re.sub(r'[a-zA-Z\s]', '', str(numeric_value))
+                    if numeric_value:
+                        numeric_value = numeric_value.replace(',', '')
+                        try:
+                            numeric_value = float(numeric_value)
+                        except ValueError:
+                            numeric_value = None
+                    else:
+                        numeric_value = None
+                
+                audit_display_name = rename_audits.get(audit, audit)
+                if audit_display_name in sec_audits:
+                    audit_display_name += ", sec"
+                elif audit_display_name in ms_audits:
+                    audit_display_name += ", ms"
+                
+                data_row = {
+                    "Step name": step_name,
+                    "Performance Score": performance_score,
+                    "Audit": audit_display_name,
+                    "Numeric Value": numeric_value
+                }
+                data_rows.append(data_row)
+        
+        return data_rows
+    
+    def _write_dataframe_to_worksheet(self, df, ws):
+        """Write pandas DataFrame to Excel worksheet."""
+        # Write headers
+        ws.cell(row=1, column=1, value="Step name")
+        for col_idx, col_name in enumerate(df.columns, 2):
+            ws.cell(row=1, column=col_idx, value=col_name)
+        
+        # Write data
+        for row_idx, (index, row) in enumerate(df.iterrows(), 2):
+            ws.cell(row=row_idx, column=1, value=index)
+            for col_idx, value in enumerate(row, 2):
+                ws.cell(row=row_idx, column=col_idx, value=value if value != '' else None)
+    
+    def _apply_formatting(self, ws, df):
+        """Apply Excel formatting to the worksheet."""
+        # Apply header formatting
+        header_fill = self.PatternFill(start_color="7FD5D8", end_color="7FD5D8", fill_type="solid")
+        for cell in ws[1]:
+            cell.fill = header_fill
+        
+        # Set alignment for 'Step name' column
+        for row in ws.iter_rows(min_row=2, min_col=1, max_col=1):
+            for cell in row:
+                cell.alignment = self.Alignment(horizontal='left')
+        
+        # Apply conditional formatting
+        for col_index, col_name in enumerate(df.columns, 2):
+            column_letter = self.get_column_letter(col_index)
+            
+            if col_name in ["cumulative-layout-shift"]:
+                self._apply_conditional_formatting(ws, column_letter, [0.1, 0.25], ["AFF2C9", "FFE699", "F7A9A9"])
+            elif col_name in ["first-contentful-paint, sec"]:
+                self._apply_conditional_formatting(ws, column_letter, [1.8, 3], ["AFF2C9", "FFE699", "F7A9A9"])
+            elif col_name in ["largest-contentful-paint, sec"]:
+                self._apply_conditional_formatting(ws, column_letter, [2.5, 4], ["AFF2C9", "FFE699", "F7A9A9"])
+        
+        # Apply borders
+        self._apply_borders(ws)
+        
+        # Auto-adjust column widths
+        self._auto_adjust_column_width(ws)
+    
+    def _apply_conditional_formatting(self, ws, column_letter, thresholds, colors):
+        """Apply conditional formatting to a column."""
+        ws.conditional_formatting.add(
+            f'{column_letter}2:{column_letter}{ws.max_row}',
+            self.CellIsRule(
+                operator='lessThanOrEqual', 
+                formula=[str(thresholds[0])], 
+                stopIfTrue=True, 
+                fill=self.PatternFill(start_color=colors[0], end_color=colors[0], fill_type="solid")
+            )
+        )
+        ws.conditional_formatting.add(
+            f'{column_letter}2:{column_letter}{ws.max_row}',
+            self.CellIsRule(
+                operator='between', 
+                formula=[str(thresholds[0]+0.0001), str(thresholds[1])], 
+                stopIfTrue=True, 
+                fill=self.PatternFill(start_color=colors[1], end_color=colors[1], fill_type="solid")
+            )
+        )
+        ws.conditional_formatting.add(
+            f'{column_letter}2:{column_letter}{ws.max_row}',
+            self.CellIsRule(
+                operator='greaterThanOrEqual', 
+                formula=[str(thresholds[1]+0.0001)], 
+                stopIfTrue=True, 
+                fill=self.PatternFill(start_color=colors[2], end_color=colors[2], fill_type="solid")
+            )
+        )
+    
+    def _apply_borders(self, ws):
+        """Apply borders to all data cells."""
+        thin_border = self.Border(
+            left=self.Side(style='thin'), 
+            right=self.Side(style='thin'), 
+            top=self.Side(style='thin'), 
+            bottom=self.Side(style='thin')
+        )
+        for row in ws.iter_rows(min_row=2, min_col=2, max_col=ws.max_column, max_row=ws.max_row):
+            for cell in row:
+                cell.border = thin_border
+    
+    def _auto_adjust_column_width(self, ws):
+        """Auto-adjust column widths."""
+        for col in ws.columns:
+            max_length = 0
+            column = col[0].column_letter
+            for cell in col:
+                try:
+                    if len(str(cell.value)) > max_length:
+                        max_length = len(cell.value)
+                except:
+                    pass
+            adjusted_width = (max_length + 2)
+            ws.column_dimensions[column].width = adjusted_width
+    
+    def finalize(self):
+        """Finalize and save the Excel file."""
+        if self.workbook and self.workbook.worksheets:
+            self.workbook.save(self.output_file)
+        else:
+            raise ToolException("No worksheets were created")

--- a/alita_sdk/tools/carrier/create_ui_excel_report_tool.py
+++ b/alita_sdk/tools/carrier/create_ui_excel_report_tool.py
@@ -176,7 +176,7 @@ class CreateUIExcelReportTool(BaseTool):
         except Exception as e:
             logger.error(f"Error processing UI report: {e}")
             raise ToolException(f"Error processing UI report: {e}")
-    
+        
     def _create_worksheet_name(self, json_file_name):
         """Create a valid worksheet name from JSON file name."""
         # Remove .json extension
@@ -190,7 +190,16 @@ class CreateUIExcelReportTool(BaseTool):
         name = name.replace('/', '_').replace('\\', '_').replace('[', '_').replace(']', '_')
         name = name.replace('*', '_').replace('?', '_').replace(':', '_')
         
-        # Truncate if too long
+        # Extract only the timestamp part (remove everything after the time)
+        # Expected format: "24Jun2025_02_14_37_user-flow.re" -> "24Jun2025_02_14_37"
+        parts = name.split('_')
+        if len(parts) >= 4:
+            # Keep first 4 parts which should be: date + 3 time parts
+            # Example: ["24Jun2025", "02", "14", "37", "user-flow.re"] -> ["24Jun2025", "02", "14", "37"]
+            timestamp_parts = parts[:4]
+            name = '_'.join(timestamp_parts)
+        
+        # Ensure it's within Excel's 31 character limit
         if len(name) > 31:
             name = name[:31]
         

--- a/alita_sdk/tools/carrier/create_ui_test_tool.py
+++ b/alita_sdk/tools/carrier/create_ui_test_tool.py
@@ -1,0 +1,199 @@
+import logging
+import json
+import traceback
+from typing import Type
+from langchain_core.tools import BaseTool, ToolException
+from pydantic.fields import Field
+from pydantic import create_model, BaseModel
+from .api_wrapper import CarrierAPIWrapper
+
+logger = logging.getLogger(__name__)
+
+
+class CreateUITestTool(BaseTool):
+    api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
+    name: str = "create_ui_test"
+    description: str = "Create a new UI test in the Carrier platform."
+    args_schema: Type[BaseModel] = create_model(
+        "CreateUITestInput",
+        **{
+            "name": (str, Field(default="", description="Test name")),
+            "test_type": (str, Field(default="", description="Test type")),
+            "env_type": (str, Field(default="", description="Environment type")),
+            "entrypoint": (str, Field(default="", description="Entry point file (e.g., my_test.js)")),
+            "runner": (str, Field(default="", description="Test runner type")),
+            "repo": (str, Field(default="", description="Git repository URL")),
+            "branch": (str, Field(default="", description="Git branch name")),
+            "username": (str, Field(default="", description="Git username")),
+            "password": (str, Field(default="", description="Git password")),
+            "cpu_quota": (int, Field(default=2, description="CPU quota (cores)")),
+            "memory_quota": (int, Field(default=5, description="Memory quota (GB)")),
+            "custom_cmd": (str, Field(default="", description="Optional custom command")),
+            "parallel_runners": (int, Field(default=1, description="Number of parallel runners")),
+            "loops": (int, Field(default=1, description="Number of loops")),
+            "aggregation": (str, Field(default="max", description="Aggregation method (max, min, avg)")),
+        }
+    )
+
+    def _run(self, **kwargs):
+        try:
+            # Check if all required parameters are provided
+            required_params = ["name", "test_type", "env_type", "entrypoint", "runner", "repo", "branch", "username", "password"]
+            missing_params = []
+            
+            for param in required_params:
+                if not kwargs.get(param) or kwargs.get(param).strip() == "":
+                    missing_params.append(param)
+            
+            if missing_params:
+                return self._missing_parameters_response(missing_params)
+            
+            # Create the UI test
+            return self._create_ui_test(kwargs)
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error creating UI test: {stacktrace}")
+            raise ToolException(stacktrace)
+
+    def _missing_parameters_response(self, missing_params=None):
+        """Response when required parameters are missing."""
+        available_runners = [
+            "Lighthouse-NPM_V12",
+            "Lighthouse-Nodejs", 
+            "Lighthouse-NPM",
+            "Lighthouse-NPM_V11",
+            "Sitespeed (Browsertime)",
+            "Sitespeed (New Entrypoint BETA)",
+            "Sitespeed (New Version BETA)",
+            "Sitespeed V36"
+        ]
+        
+        message = [
+            "# 📝 Create UI Test - Required Parameters",
+            "",
+            "To create a new UI test, please provide the following parameters:",
+            "",
+            "## 🔴 Required Parameters:",
+            "- **name**: Test name (e.g., 'My UI Test')",
+            "- **test_type**: Test type (e.g., 'performance')",
+            "- **env_type**: Environment type (e.g., 'staging')",
+            "- **entrypoint**: Entry point file (e.g., 'my_test.js')",
+            "- **runner**: Test runner (see available options below)",
+            "- **repo**: Git repository URL (e.g., 'https://github.com/user/repo.git')",
+            "- **branch**: Git branch name (e.g., 'main')",
+            "- **username**: Git username",
+            "- **password**: Git password",
+            "",
+            "## 🟡 Optional Parameters:",
+            "- **cpu_quota**: CPU quota in cores (default: 2)",
+            "- **memory_quota**: Memory quota in GB (default: 5)",            "- **custom_cmd**: Optional custom command (e.g., '--login=\"qwerty\"')",
+            "- **parallel_runners**: Number of parallel runners (default: 1)",
+            "- **loops**: Number of loops (default: 1)",
+            "",
+            "## 🚀 Available Runners:",
+        ]
+        
+        for runner in available_runners:
+            message.append(f"- {runner}")
+        
+        message.extend([
+            "",
+            "## 💡 Example:",
+            "```",
+            "name: 'My Performance Test'",
+            "test_type: 'performance'",
+            "env_type: 'staging'",
+            "entrypoint: 'lighthouse_test.js'",
+            "runner: 'Lighthouse-NPM_V12'",
+            "repo: 'https://github.com/mycompany/tests.git'",            "branch: 'main'",
+            "username: 'myusername'",
+            "password: 'mypassword'",
+            "```",
+            "",
+            "**Note:** Aggregation method is automatically set to 'max'."
+        ])
+        
+        if missing_params:
+            message.insert(2, f"❌ **Missing parameters:** {', '.join(missing_params)}")
+            message.insert(3, "")
+        
+        return {
+            "message": "\n".join(message)
+        }
+
+    def _create_ui_test(self, params):
+        """Create UI test using the provided parameters."""
+        try:
+            # Construct the POST body
+            post_body = {
+                "common_params": {
+                    "name": params["name"],
+                    "test_type": params["test_type"],
+                    "env_type": params["env_type"],
+                    "entrypoint": params["entrypoint"],
+                    "runner": params["runner"],
+                    "source": {
+                        "name": "git_https",
+                        "repo": params["repo"],
+                        "branch": params["branch"],
+                        "username": params["username"],
+                        "password": params["password"]
+                    },
+                    "env_vars": {
+                        "cpu_quota": params.get("cpu_quota", 2),
+                        "memory_quota": params.get("memory_quota", 5),
+                        "cloud_settings": {}
+                    },
+                    "parallel_runners": params.get("parallel_runners", 1),
+                    "cc_env_vars": {},
+                    "location": "default",
+                    "loops": params.get("loops", 1),
+                    "aggregation": params.get("aggregation", "max")
+                },
+                "test_parameters": [],
+                "integrations": {},
+                "schedules": [],
+                "run_test": False
+            }
+            
+            # Add custom_cmd if provided
+            if params.get("custom_cmd") and params["custom_cmd"].strip():
+                post_body["common_params"]["env_vars"]["custom_cmd"] = params["custom_cmd"]
+            
+            # Make the API call to create the UI test using the API wrapper
+            response = self.api_wrapper.create_ui_test(post_body)
+            
+            if response:
+                test_id = response.get("id") if isinstance(response, dict) else "Unknown"
+                
+                return f"""# ✅ UI Test Created Successfully!
+
+## Test Information:
+- **Test ID:** `{test_id}`
+- **Name:** `{params['name']}`
+- **Type:** `{params['test_type']}`
+- **Environment:** `{params['env_type']}`
+- **Runner:** `{params['runner']}`
+- **Repository:** `{params['repo']}`
+- **Branch:** `{params['branch']}`
+- **Entry Point:** `{params['entrypoint']}`
+
+## Configuration:
+- **CPU Quota:** {params.get('cpu_quota', 2)} cores
+- **Memory Quota:** {params.get('memory_quota', 5)} GB
+- **Parallel Runners:** {params.get('parallel_runners', 1)}
+- **Loops:** {params.get('loops', 1)}
+- **Aggregation:** {params.get('aggregation', 'max')}
+{f"- **Custom Command:** `{params['custom_cmd']}`" if params.get('custom_cmd') else ""}
+
+## 🎯 Next Steps:
+- Your UI test has been created and is ready to run
+- You can execute it using the UI test runner tools
+- Configure schedules and integrations as needed"""
+            else:
+                return "❌ **Failed to create UI test. Please check your parameters and try again.**"
+                
+        except Exception as e:
+            logger.error(f"Error creating UI test: {e}")
+            raise ToolException(f"Failed to create UI test: {str(e)}")

--- a/alita_sdk/tools/carrier/lighthouse_excel_reporter.py
+++ b/alita_sdk/tools/carrier/lighthouse_excel_reporter.py
@@ -1,0 +1,155 @@
+import json
+import pandas as pd
+from urllib.parse import urlparse
+from collections import OrderedDict
+import re
+from openpyxl.styles import Alignment, PatternFill, Border, Side
+from openpyxl.formatting.rule import CellIsRule
+from openpyxl.utils import get_column_letter
+
+# Path to the Lighthouse JSON report
+report_path = 'user-flow.report.json'
+
+# Audits to extract from the report
+performance_audits = [
+    'first-contentful-paint',
+    'speed-index',
+    'interactive',
+    'total-blocking-time',
+    'largest-contentful-paint',
+    'cumulative-layout-shift',
+    'network-requests',
+    'bootup-time',
+    'interaction-to-next-paint',
+    'server-response-time',
+]
+
+# Create lists for audits to be appended with ", sec" and ", ms"
+sec_audits = ['first-contentful-paint', 'interactive', 'largest-contentful-paint', 'mainthread-work-breakdown', 'network-requests', 'speed-index', 'javaScript-execution-time']
+ms_audits = ['interaction-to-next-paint', 'total-blocking-time', 'time-to-first-byte']
+
+# Rename mappings
+rename_audits = {
+    'bootup-time': 'javaScript-execution-time',
+    'server-response-time': 'time-to-first-byte'
+}
+
+def extract_application_name(url):
+    parsed_url = urlparse(url)
+    hostname_parts = parsed_url.hostname.split('.') if parsed_url.hostname else []
+    application_name = hostname_parts[0] if len(hostname_parts) > 1 else '3rd-party'
+    return application_name
+
+def apply_excel_conditional_formatting(ws, column_letter, thresholds, colors):
+    ws.conditional_formatting.add(f'{column_letter}2:{column_letter}{ws.max_row}',
+                                  CellIsRule(operator='lessThanOrEqual', formula=[str(thresholds[0])], stopIfTrue=True, fill=PatternFill(start_color=colors[0], end_color=colors[0], fill_type="solid")))
+    ws.conditional_formatting.add(f'{column_letter}2:{column_letter}{ws.max_row}',
+                                  CellIsRule(operator='between', formula=[str(thresholds[0]+0.0001), str(thresholds[1])], stopIfTrue=True, fill=PatternFill(start_color=colors[1], end_color=colors[1], fill_type="solid")))
+    ws.conditional_formatting.add(f'{column_letter}2:{column_letter}{ws.max_row}',
+                                  CellIsRule(operator='greaterThanOrEqual', formula=[str(thresholds[1]+0.0001)], stopIfTrue=True, fill=PatternFill(start_color=colors[2], end_color=colors[2], fill_type="solid")))
+
+def apply_all_borders(ws):
+    thin_border = Border(left=Side(style='thin'), 
+                         right=Side(style='thin'), 
+                         top=Side(style='thin'), 
+                         bottom=Side(style='thin'))
+    for row in ws.iter_rows(min_row=2, min_col=2, max_col=ws.max_column, max_row=ws.max_row):
+        for cell in row:
+            cell.border = thin_border
+
+def auto_adjust_column_width(ws):
+    for col in ws.columns:
+        max_length = 0
+        column = col[0].column_letter  # Get the column name
+        for cell in col:
+            try:
+                if len(str(cell.value)) > max_length:
+                    max_length = len(cell.value)
+            except:
+                pass
+        adjusted_width = (max_length + 2)
+        ws.column_dimensions[column].width = adjusted_width
+
+try:
+    with open(report_path, 'r', encoding='utf-8') as file:
+        data = json.load(file)
+
+    data_rows = []
+    step_order = OrderedDict()
+
+    for index, step in enumerate(data.get('steps', [])):
+        step_name = step.get('name', 'unknown_step')
+        step_order[step_name] = index
+        lhr_data = step.get('lhr', {})
+        url = lhr_data.get('finalDisplayedUrl', '3rd-party')
+        application_name = extract_application_name(url)
+
+        performance_score = lhr_data.get('categories', {}).get('performance', {}).get('score')
+        performance_score = performance_score * 100 if performance_score is not None else None
+
+        for audit in performance_audits:
+            audit_result = lhr_data.get('audits', {}).get(audit, {})
+            numeric_value = audit_result.get('displayValue')
+
+            if numeric_value is not None:
+                numeric_value = re.sub(r'[a-zA-Z\s]', '', numeric_value)
+                if numeric_value:
+                    numeric_value = numeric_value.replace(',', '')
+                    numeric_value = float(numeric_value)
+                else:
+                    numeric_value = None
+
+            audit_display_name = rename_audits.get(audit, audit)
+            if audit_display_name in sec_audits:
+                audit_display_name += ", sec"
+            elif audit_display_name in ms_audits:
+                audit_display_name += ", ms"
+
+            data_row = {"Step name": step_name,
+                        "Performance Score": performance_score,
+                        "Audit": audit_display_name,
+                        "Numeric Value": numeric_value
+                        }
+            data_rows.append(data_row)
+
+    df = pd.DataFrame(data_rows)
+    df = df.pivot_table(index="Step name", columns="Audit", values="Numeric Value", aggfunc='mean')
+    df = df.fillna('')
+    df = df.reindex(step_order.keys())
+
+    # Save DataFrame to Excel using openpyxl for styling
+    writer = pd.ExcelWriter("output.xlsx", engine='openpyxl')
+    df.to_excel(writer, index=True)
+    workbook = writer.book
+    worksheet = writer.sheets['Sheet1']
+
+    # Apply styles
+    header_fill = PatternFill(start_color="7FD5D8", end_color="7FD5D8", fill_type="solid")
+    for cell in worksheet[1]:  # Apply styles to header row
+        cell.fill = header_fill
+
+    # Set alignment for 'Step name' column
+    for row in worksheet.iter_rows(min_row=2, min_col=1, max_col=1):
+        for cell in row:
+            cell.alignment = Alignment(horizontal='left')
+
+    # Apply conditional formatting
+    for col_index, col_name in enumerate(df.columns, 2):  # Start from 2 to account for index column
+        column_letter = get_column_letter(col_index)
+        if col_name in ["cumulative-layout-shift"]:
+            apply_excel_conditional_formatting(worksheet, column_letter, [0.1, 0.25], ["AFF2C9", "FFE699", "F7A9A9"])
+        elif col_name in ["first-contentful-paint, sec"]:
+            apply_excel_conditional_formatting(worksheet, column_letter, [1.8, 3], ["AFF2C9", "FFE699", "F7A9A9"])
+        elif col_name in ["largest-contentful-paint, sec"]:
+            apply_excel_conditional_formatting(worksheet, column_letter, [2.5, 4], ["AFF2C9", "FFE699", "F7A9A9"])
+
+    # Apply all borders to the data cells
+    apply_all_borders(worksheet)
+
+    # Auto-adjust column widths
+    auto_adjust_column_width(worksheet)
+
+    writer.close()  # Correct method to finalize and save the file
+
+except Exception as e:
+    print(f"An error occurred: {e}")

--- a/alita_sdk/tools/carrier/run_ui_test_tool.py
+++ b/alita_sdk/tools/carrier/run_ui_test_tool.py
@@ -14,14 +14,23 @@ logger = logging.getLogger(__name__)
 class RunUITestTool(BaseTool):
     api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
     name: str = "run_ui_test"
-    description: str = "Run and execute UI tests from the Carrier platform. Use this tool when user wants to run, execute, or start a UI test. Provide either test ID or test name, or leave empty to see available tests."
+    description: str = ("Run and execute UI tests from the Carrier platform. Use this tool when user wants to run, execute, or start a UI test. "
+                        "Provide either test ID or test name, or leave empty to see available tests. "
+                        "Optionally provide custom parameters like loops, cpu_quota, memory_quota, cloud_settings, or custom_cmd.")
     args_schema: Type[BaseModel] = create_model(
         "RunUITestInput",
         test_id=(str, Field(default="", description="Test ID to execute")),
         test_name=(str, Field(default="", description="Test name to execute")),
+        loops=(int, Field(default=None, description="Number of loops to run the test")),
+        cpu_quota=(str, Field(default=None, description="CPU quota for the test runner")),
+        memory_quota=(str, Field(default=None, description="Memory quota for the test runner")),
+        cloud_settings=(str, Field(default=None, description="Cloud settings name for the test runner")),
+        custom_cmd=(str, Field(default=None, description="Custom command to run with the test")),
     )
     
-    def _run(self, test_id: str = "", test_name: str = ""):
+    def _run(self, test_id: str = "", test_name: str = "", loops: int = None, 
+             cpu_quota: str = None, memory_quota: str = None, 
+             cloud_settings: str = None, custom_cmd: str = None):
         try:
             # Check if neither test_id nor test_name is provided
             if (not test_id or test_id.strip() == "") and (not test_name or test_name.strip() == ""):
@@ -60,8 +69,7 @@ class RunUITestTool(BaseTool):
                         if test_name.lower() in test.get("name", "").lower():
                             test_data = test
                             ui_test_id = test.get("id")
-                            break
-            
+                            break            
             # If still not found and test_id was provided but not numeric, try as name
             if not test_data and test_id and test_id.strip() and not test_id.isdigit():
                 for test in ui_tests:
@@ -91,14 +99,22 @@ class RunUITestTool(BaseTool):
                 
                 return f"Test not found for {' or '.join(search_criteria)}. Available UI tests:\n" + "\n".join(available_tests)
             
+            # Check if custom parameters are provided
+            has_custom_params = any([loops is not None, cpu_quota is not None, memory_quota is not None, 
+                                   cloud_settings is not None, custom_cmd is not None])
+            
+            # If no custom parameters provided, show info message with default values and available options
+            if not has_custom_params:
+                return self._show_test_parameter_info(test_data, ui_test_id)
+            
             # Get detailed test configuration for the POST request
             test_details = self._get_ui_test_details(ui_test_id)
             
             if not test_details:
                 return f"Could not retrieve test details for test ID {ui_test_id}."
             
-            # Prepare POST request data based on the reference code
-            post_data = self._prepare_post_data(test_details)
+            # Prepare POST request data with custom parameters
+            post_data = self._prepare_post_data_with_custom_params(test_details, loops, cpu_quota, memory_quota, cloud_settings, custom_cmd)
             
             # Execute the UI test
             result_id = self.api_wrapper.run_ui_test(str(ui_test_id), post_data)
@@ -145,9 +161,84 @@ class RunUITestTool(BaseTool):
             stacktrace = traceback.format_exc()
             logger.error(f"Error getting UI test details: {stacktrace}")
             return None
+      
+    def _show_test_parameter_info(self, test_data, test_id):
+        """Show information about test parameters that can be changed."""
+        try:
+            # Get current default values from test data
+            env_vars = test_data.get("env_vars", {})
+            
+            info_message = []
+            info_message.append(f"Test '{test_data.get('name')}' (ID: {test_id}) found!")
+            info_message.append("\nCurrent default parameters:")
+            info_message.append(f"- loops: 1 (default override)")
+            info_message.append(f"- cpu_quota: {env_vars.get('cpu_quota', 'Not set')}")
+            info_message.append(f"- memory_quota: {env_vars.get('memory_quota', 'Not set')}")
+            info_message.append(f"- cloud_settings: {env_vars.get('cloud_settings', 'Not set')}")
+            info_message.append(f"- custom_cmd: {env_vars.get('custom_cmd', 'Not set')}")
+              # Always try to get and display available cloud settings - this is critical information
+            info_message.append("\n" + "="*60)
+            info_message.append("🏃 AVAILABLE RUNNERS - CHOOSE ONE FOR cloud_settings:")
+            info_message.append("="*60)
+            
+            try:
+                locations_data = self.api_wrapper.get_locations()
+                if not locations_data:
+                    info_message.append("⚠️  Could not fetch locations data - API returned empty response")
+                else:
+                    cloud_regions = locations_data.get("cloud_regions", [])
+                    public_regions = locations_data.get("public_regions", [])
+                    project_regions = locations_data.get("project_regions", [])
+                      # Add public regions information (these are the most commonly used)
+                    info_message.append("\n🌐 PUBLIC REGIONS (use these names):")
+                    if public_regions:
+                        for region in public_regions:
+                            info_message.append(f"  ✅ '{region}'")
+                    else:
+                        info_message.append("  ❌ No public regions available")
+                    
+                    # Add project regions information
+                    if project_regions:
+                        info_message.append("\n🏢 PROJECT REGIONS (use these names):")
+                        for region in project_regions:
+                            info_message.append(f"  ✅ '{region}'")
+                    
+                    # Add cloud regions information
+                    if cloud_regions:
+                        info_message.append("\n☁️  CLOUD REGIONS (advanced - use full names):")
+                        for region in cloud_regions:
+                            region_name = region.get("name", "Unknown")
+                            info_message.append(f"  ✅ '{region_name}'")
+                        
+            except Exception as e:
+                logger.error(f"Error fetching locations: {e}")
+                info_message.append("❌ ERROR: Could not fetch available runners!")
+                info_message.append(f"   Reason: {str(e)}")
+                info_message.append("   Please check your API connection and try again.")
+            
+            info_message.append("="*60)            
+            info_message.append("\n📋 HOW TO USE:")
+            info_message.append("To run this test with custom parameters, specify the values you want to change.")
+            info_message.append("\n💡 EXAMPLES:")
+            info_message.append("  • Use default runner: cloud_settings='default'")
+            info_message.append("  • Change loops: loops=5")
+            info_message.append("  • Change resources: cpu_quota='2', memory_quota='4Gi'")
+            info_message.append("  • Full example: loops=3, cloud_settings='default', cpu_quota='2'")
+            info_message.append("\n📝 RUNNER TYPES:")
+            info_message.append("  • Public regions: Use empty cloud_settings {}, location = runner name")
+            info_message.append("  • Project regions: Use empty cloud_settings {}, location = runner name") 
+            info_message.append("  • Cloud regions: Use full cloud configuration object")
+            
+            return "\n".join(info_message)
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error showing test parameter info: {stacktrace}")
+            raise ToolException(stacktrace)
     
-    def _prepare_post_data(self, test_data):
-        """Prepare POST request data based on the reference code."""
+    def _prepare_post_data_with_custom_params(self, test_data, loops=None, cpu_quota=None, 
+                                            memory_quota=None, cloud_settings=None, custom_cmd=None):
+        """Prepare POST request data with custom parameters."""
         try:
             # Extract values from the test data
             test_parameters = test_data.get("test_parameters", [])
@@ -162,29 +253,95 @@ class RunUITestTool(BaseTool):
             
             # Extract S3 integration
             s3_integration = integrations.get("system", {}).get("s3_integration", {})
-            
-            # Find specific test parameters by name
+              # Find specific test parameters by name
             def find_param_by_name(params, name):
                 for param in params:
                     if param.get("name") == name:
                         return param
-                return {}
+                return {}            
+            # Handle cloud_settings parameter and location
+            final_cloud_settings = env_vars.get("cloud_settings")
+            final_location = location  # Use original location as default
             
-            # Prepare the POST request body
+            if cloud_settings:
+                try:
+                    locations_data = self.api_wrapper.get_locations()
+                    cloud_regions = locations_data.get("cloud_regions", [])
+                    public_regions = locations_data.get("public_regions", [])
+                    project_regions = locations_data.get("project_regions", [])
+                    
+                    # Check if it's a public region first
+                    if cloud_settings in public_regions:
+                        # For public regions, use empty cloud_settings and set location to the runner name
+                        final_cloud_settings = {}
+                        final_location = cloud_settings
+                    # Check if it's a project region
+                    elif cloud_settings in project_regions:
+                        # For project regions, use empty cloud_settings and set location to the runner name
+                        final_cloud_settings = {}
+                        final_location = cloud_settings
+                    else:
+                        # Try to find exact match in cloud regions
+                        found_match = False
+                        for region in cloud_regions:
+                            if region.get("name", "").lower() == cloud_settings.lower():
+                                # Get the complete cloud_settings object and add the missing fields
+                                region_cloud_settings = region.get("cloud_settings", {})
+                                # Add the additional fields that are expected in the POST request
+                                region_cloud_settings.update({
+                                    "instance_type": "on-demand",
+                                    "ec2_instance_type": "t2.xlarge", 
+                                    "cpu_cores_limit": int(cpu_quota) if cpu_quota else env_vars.get("cpu_quota", 1),
+                                    "memory_limit": int(memory_quota) if memory_quota else env_vars.get("memory_quota", 8),
+                                    "concurrency": 1
+                                })
+                                final_cloud_settings = region_cloud_settings
+                                final_location = location  # Keep original location for cloud regions
+                                found_match = True
+                                break
+                        
+                        # If no exact match in cloud regions, try partial match
+                        if not found_match:
+                            for region in cloud_regions:
+                                if cloud_settings.lower() in region.get("name", "").lower():
+                                    region_cloud_settings = region.get("cloud_settings", {})
+                                    region_cloud_settings.update({
+                                        "instance_type": "on-demand",
+                                        "ec2_instance_type": "t2.xlarge",
+                                        "cpu_cores_limit": int(cpu_quota) if cpu_quota else env_vars.get("cpu_quota", 1),
+                                        "memory_limit": int(memory_quota) if memory_quota else env_vars.get("memory_quota", 8),
+                                        "concurrency": 1
+                                    })
+                                    final_cloud_settings = region_cloud_settings
+                                    final_location = location  # Keep original location for cloud regions
+                                    found_match = True
+                                    break
+                        
+                        # If still no match found, treat as public region fallback
+                        if not found_match:
+                            final_cloud_settings = {}
+                            final_location = cloud_settings
+                            
+                except Exception as e:
+                    logger.error(f"Error processing cloud_settings: {e}")
+                    # Use the provided value as-is if we can't process it
+                    final_cloud_settings = cloud_settings
+                    final_location = location
+            
+            # Prepare the POST request body with custom parameters
             post_data = {
                 "common_params": {
                     "name": find_param_by_name(test_parameters, "test_name"),
                     "test_type": find_param_by_name(test_parameters, "test_type"),
                     "env_type": find_param_by_name(test_parameters, "env_type"),
                     "env_vars": {
-                        "cpu_quota": env_vars.get("cpu_quota"),
-                        "memory_quota": env_vars.get("memory_quota"),
-                        "cloud_settings": env_vars.get("cloud_settings"),
+                        "cpu_quota": cpu_quota if cpu_quota is not None else env_vars.get("cpu_quota"),
+                        "memory_quota": memory_quota if memory_quota is not None else env_vars.get("memory_quota"),
+                        "cloud_settings": final_cloud_settings,
                         "ENV": "prod",  # Override as per reference code
-                        "custom_cmd": env_vars.get("custom_cmd")
-                    },
-                    "parallel_runners": parallel_runners,
-                    "location": location
+                        "custom_cmd": custom_cmd if custom_cmd is not None else env_vars.get("custom_cmd", "")
+                    },                    "parallel_runners": parallel_runners,
+                    "location": final_location
                 },
                 "test_parameters": test_parameters,
                 "integrations": {
@@ -203,7 +360,7 @@ class RunUITestTool(BaseTool):
                         }
                     }
                 },
-                "loops": 1,  # Override the loops value to 1 as per reference code
+                "loops": loops if loops is not None else 1,  # Use custom loops or default to 1
                 "aggregation": aggregation
             }
             
@@ -211,9 +368,9 @@ class RunUITestTool(BaseTool):
             
         except Exception:
             stacktrace = traceback.format_exc()
-            logger.error(f"Error preparing POST data: {stacktrace}")
+            logger.error(f"Error preparing POST data with custom parameters: {stacktrace}")
             raise ToolException(stacktrace)
-    
+
     def _missing_input_response(self):
         """Response when required input is missing."""
         try:

--- a/alita_sdk/tools/carrier/run_ui_test_tool.py
+++ b/alita_sdk/tools/carrier/run_ui_test_tool.py
@@ -1,0 +1,237 @@
+import logging
+import json
+import traceback
+from typing import Type
+from langchain_core.tools import BaseTool, ToolException
+from pydantic.fields import Field
+from pydantic import create_model, BaseModel
+from .api_wrapper import CarrierAPIWrapper
+
+
+logger = logging.getLogger(__name__)
+
+
+class RunUITestTool(BaseTool):
+    api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
+    name: str = "run_ui_test"
+    description: str = "Run and execute UI tests from the Carrier platform. Use this tool when user wants to run, execute, or start a UI test. Provide either test ID or test name, or leave empty to see available tests."
+    args_schema: Type[BaseModel] = create_model(
+        "RunUITestInput",
+        test_id=(str, Field(default="", description="Test ID to execute")),
+        test_name=(str, Field(default="", description="Test name to execute")),
+    )
+    
+    def _run(self, test_id: str = "", test_name: str = ""):
+        try:
+            # Check if neither test_id nor test_name is provided
+            if (not test_id or test_id.strip() == "") and (not test_name or test_name.strip() == ""):
+                return self._missing_input_response()
+            
+            # Check if user wants to see the list of tests (can be in test_name field)
+            if test_name.lower() in ["show me the list of ui tests", "list ui tests", "show ui tests"]:
+                return self._show_ui_tests_list()
+              # Get UI tests list only when we need to search for and run a test
+            ui_tests = self.api_wrapper.get_ui_tests_list()
+            
+            # Find the test by ID or name
+            test_data = None
+            ui_test_id = None
+            
+            # Try to find by ID first (if test_id is provided and numeric)
+            if test_id and test_id.strip() and test_id.isdigit():
+                test_id_int = int(test_id)
+                for test in ui_tests:
+                    if test.get("id") == test_id_int:
+                        test_data = test
+                        ui_test_id = test_id_int
+                        break
+            
+            # If not found by ID, try to find by name (if test_name is provided)
+            if not test_data and test_name and test_name.strip():
+                for test in ui_tests:
+                    if test.get("name", "").lower() == test_name.lower():
+                        test_data = test
+                        ui_test_id = test.get("id")
+                        break
+                        
+                # If exact match not found, try partial match
+                if not test_data:
+                    for test in ui_tests:
+                        if test_name.lower() in test.get("name", "").lower():
+                            test_data = test
+                            ui_test_id = test.get("id")
+                            break
+            
+            # If still not found and test_id was provided but not numeric, try as name
+            if not test_data and test_id and test_id.strip() and not test_id.isdigit():
+                for test in ui_tests:
+                    if test.get("name", "").lower() == test_id.lower():
+                        test_data = test
+                        ui_test_id = test.get("id")
+                        break
+                        
+                # If exact match not found, try partial match
+                if not test_data:
+                    for test in ui_tests:
+                        if test_id.lower() in test.get("name", "").lower():
+                            test_data = test
+                            ui_test_id = test.get("id")
+                            break
+            
+            if not test_data:
+                available_tests = []
+                for test in ui_tests:
+                    available_tests.append(f"ID: {test.get('id')}, Name: {test.get('name')}")
+                
+                search_criteria = []
+                if test_id:
+                    search_criteria.append(f"ID: {test_id}")
+                if test_name:
+                    search_criteria.append(f"Name: {test_name}")
+                
+                return f"Test not found for {' or '.join(search_criteria)}. Available UI tests:\n" + "\n".join(available_tests)
+            
+            # Get detailed test configuration for the POST request
+            test_details = self._get_ui_test_details(ui_test_id)
+            
+            if not test_details:
+                return f"Could not retrieve test details for test ID {ui_test_id}."
+            
+            # Prepare POST request data based on the reference code
+            post_data = self._prepare_post_data(test_details)
+            
+            # Execute the UI test
+            result_id = self.api_wrapper.run_ui_test(str(ui_test_id), post_data)
+            
+            return f"UI test started successfully. Result ID: {result_id}. " \
+                   f"Link to report: {self.api_wrapper.url.rstrip('/')}/-/performance/ui/results?result_id={result_id}"
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error running UI test: {stacktrace}")
+            raise ToolException(stacktrace)
+    
+    def _show_ui_tests_list(self):
+        """Show the list of available UI tests."""
+        try:
+            ui_tests = self.api_wrapper.get_ui_tests_list()
+            
+            if not ui_tests:
+                return "No UI tests found."
+            
+            test_list = ["Available UI Tests:"]
+            for test in ui_tests:
+                test_list.append(f"- ID: {test.get('id')}, Name: {test.get('name')}, Runner: {test.get('runner')}")
+            
+            return "\n".join(test_list)
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error fetching UI tests list: {stacktrace}")
+            raise ToolException(stacktrace)
+    
+    def _get_ui_test_details(self, test_id: int):
+        """Get detailed test configuration from the UI tests list."""
+        try:
+            ui_tests = self.api_wrapper.get_ui_tests_list()
+            
+            for test in ui_tests:
+                if test.get("id") == test_id:
+                    return test
+            
+            return None
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error getting UI test details: {stacktrace}")
+            return None
+    
+    def _prepare_post_data(self, test_data):
+        """Prepare POST request data based on the reference code."""
+        try:
+            # Extract values from the test data
+            test_parameters = test_data.get("test_parameters", [])
+            env_vars = test_data.get("env_vars", {})
+            integrations = test_data.get("integrations", {})
+            location = test_data.get("location", "")
+            parallel_runners = test_data.get("parallel_runners", 1)
+            aggregation = test_data.get("aggregation", "max")
+            
+            # Extract reporter email for integrations
+            reporter_email = integrations.get("reporters", {}).get("reporter_email", {})
+            
+            # Extract S3 integration
+            s3_integration = integrations.get("system", {}).get("s3_integration", {})
+            
+            # Find specific test parameters by name
+            def find_param_by_name(params, name):
+                for param in params:
+                    if param.get("name") == name:
+                        return param
+                return {}
+            
+            # Prepare the POST request body
+            post_data = {
+                "common_params": {
+                    "name": find_param_by_name(test_parameters, "test_name"),
+                    "test_type": find_param_by_name(test_parameters, "test_type"),
+                    "env_type": find_param_by_name(test_parameters, "env_type"),
+                    "env_vars": {
+                        "cpu_quota": env_vars.get("cpu_quota"),
+                        "memory_quota": env_vars.get("memory_quota"),
+                        "cloud_settings": env_vars.get("cloud_settings"),
+                        "ENV": "prod",  # Override as per reference code
+                        "custom_cmd": env_vars.get("custom_cmd")
+                    },
+                    "parallel_runners": parallel_runners,
+                    "location": location
+                },
+                "test_parameters": test_parameters,
+                "integrations": {
+                    "reporters": {
+                        "reporter_email": {
+                            "id": reporter_email.get("id"),
+                            "is_local": reporter_email.get("is_local"),
+                            "project_id": reporter_email.get("project_id"),
+                            "recipients": reporter_email.get("recipients")
+                        }
+                    },
+                    "system": {
+                        "s3_integration": {
+                            "integration_id": s3_integration.get("integration_id"),
+                            "is_local": s3_integration.get("is_local")
+                        }
+                    }
+                },
+                "loops": 1,  # Override the loops value to 1 as per reference code
+                "aggregation": aggregation
+            }
+            
+            return post_data
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error preparing POST data: {stacktrace}")
+            raise ToolException(stacktrace)
+    
+    def _missing_input_response(self):
+        """Response when required input is missing."""
+        try:
+            available_tests = self._show_ui_tests_list()
+            return {
+                "message": "Please provide test ID or test name of your UI test.",
+                "parameters": {
+                    "test_id": None,
+                    "test_name": None,
+                },
+                "available_tests": available_tests
+            }
+        except Exception:
+            return {
+                "message": "Please provide test ID or test name of your UI test.",
+                "parameters": {
+                    "test_id": None,
+                    "test_name": None,
+                },
+                "available_tests": "Error fetching available tests."
+            }

--- a/alita_sdk/tools/carrier/tools.py
+++ b/alita_sdk/tools/carrier/tools.py
@@ -6,6 +6,7 @@ from .ui_reports_tool import GetUIReportsTool, GetUIReportByIDTool, GetUITestsTo
 from .run_ui_test_tool import RunUITestTool
 from .update_ui_test_schedule_tool import UpdateUITestScheduleTool
 from .create_ui_excel_report_tool import CreateUIExcelReportTool
+from .create_ui_test_tool import CreateUITestTool
 
 __all__ = [
     {"name": "get_ticket_list", "tool": FetchTicketsTool},
@@ -21,5 +22,6 @@ __all__ = [
     {"name": "get_ui_tests", "tool": GetUITestsTool},
     {"name": "run_ui_test", "tool": RunUITestTool},
     {"name": "update_ui_test_schedule", "tool": UpdateUITestScheduleTool},
-    {"name": "create_ui_excel_report", "tool": CreateUIExcelReportTool}
+    {"name": "create_ui_excel_report", "tool": CreateUIExcelReportTool},
+    {"name": "create_ui_test", "tool": CreateUITestTool}
 ]

--- a/alita_sdk/tools/carrier/tools.py
+++ b/alita_sdk/tools/carrier/tools.py
@@ -7,6 +7,7 @@ from .run_ui_test_tool import RunUITestTool
 from .update_ui_test_schedule_tool import UpdateUITestScheduleTool
 from .create_ui_excel_report_tool import CreateUIExcelReportTool
 from .create_ui_test_tool import CreateUITestTool
+from .cancel_ui_test_tool import CancelUITestTool
 
 __all__ = [
     {"name": "get_ticket_list", "tool": FetchTicketsTool},
@@ -23,5 +24,6 @@ __all__ = [
     {"name": "run_ui_test", "tool": RunUITestTool},
     {"name": "update_ui_test_schedule", "tool": UpdateUITestScheduleTool},
     {"name": "create_ui_excel_report", "tool": CreateUIExcelReportTool},
-    {"name": "create_ui_test", "tool": CreateUITestTool}
+    {"name": "create_ui_test", "tool": CreateUITestTool},
+    {"name": "cancel_ui_test", "tool": CancelUITestTool}
 ]

--- a/alita_sdk/tools/carrier/tools.py
+++ b/alita_sdk/tools/carrier/tools.py
@@ -3,6 +3,7 @@ from .tickets_tool import FetchTicketsTool, CreateTicketTool
 from .backend_reports_tool import GetReportsTool, GetReportByIDTool, CreateExcelReportTool
 from .backend_tests_tool import GetTestsTool, GetTestByIDTool, RunTestByIDTool
 from .ui_reports_tool import GetUIReportsTool, GetUIReportByIDTool, GetUITestsTool
+from .run_ui_test_tool import RunUITestTool
 
 __all__ = [
     {"name": "get_ticket_list", "tool": FetchTicketsTool},
@@ -15,5 +16,6 @@ __all__ = [
     {"name": "run_test_by_id", "tool": RunTestByIDTool},
     {"name": "get_ui_reports", "tool": GetUIReportsTool},
     {"name": "get_ui_report_by_id", "tool": GetUIReportByIDTool},
-    {"name": "get_ui_tests", "tool": GetUITestsTool}
+    {"name": "get_ui_tests", "tool": GetUITestsTool},
+    {"name": "run_ui_test", "tool": RunUITestTool}
 ]

--- a/alita_sdk/tools/carrier/tools.py
+++ b/alita_sdk/tools/carrier/tools.py
@@ -5,6 +5,7 @@ from .backend_tests_tool import GetTestsTool, GetTestByIDTool, RunTestByIDTool
 from .ui_reports_tool import GetUIReportsTool, GetUIReportByIDTool, GetUITestsTool
 from .run_ui_test_tool import RunUITestTool
 from .update_ui_test_schedule_tool import UpdateUITestScheduleTool
+from .create_ui_excel_report_tool import CreateUIExcelReportTool
 
 __all__ = [
     {"name": "get_ticket_list", "tool": FetchTicketsTool},
@@ -19,5 +20,6 @@ __all__ = [
     {"name": "get_ui_report_by_id", "tool": GetUIReportByIDTool},
     {"name": "get_ui_tests", "tool": GetUITestsTool},
     {"name": "run_ui_test", "tool": RunUITestTool},
-    {"name": "update_ui_test_schedule", "tool": UpdateUITestScheduleTool}
+    {"name": "update_ui_test_schedule", "tool": UpdateUITestScheduleTool},
+    {"name": "create_ui_excel_report", "tool": CreateUIExcelReportTool}
 ]

--- a/alita_sdk/tools/carrier/tools.py
+++ b/alita_sdk/tools/carrier/tools.py
@@ -4,6 +4,7 @@ from .backend_reports_tool import GetReportsTool, GetReportByIDTool, CreateExcel
 from .backend_tests_tool import GetTestsTool, GetTestByIDTool, RunTestByIDTool
 from .ui_reports_tool import GetUIReportsTool, GetUIReportByIDTool, GetUITestsTool
 from .run_ui_test_tool import RunUITestTool
+from .update_ui_test_schedule_tool import UpdateUITestScheduleTool
 
 __all__ = [
     {"name": "get_ticket_list", "tool": FetchTicketsTool},
@@ -17,5 +18,6 @@ __all__ = [
     {"name": "get_ui_reports", "tool": GetUIReportsTool},
     {"name": "get_ui_report_by_id", "tool": GetUIReportByIDTool},
     {"name": "get_ui_tests", "tool": GetUITestsTool},
-    {"name": "run_ui_test", "tool": RunUITestTool}
+    {"name": "run_ui_test", "tool": RunUITestTool},
+    {"name": "update_ui_test_schedule", "tool": UpdateUITestScheduleTool}
 ]

--- a/alita_sdk/tools/carrier/ui_reports_tool.py
+++ b/alita_sdk/tools/carrier/ui_reports_tool.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("carrier_ui_reports_tool")
 class GetUIReportsTool(BaseTool):
     api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
     name: str = "get_ui_reports"
-    description: str = "Get list of UI test reports from the Carrier platform. Optionally filter by tag and time range."
+    description: str = "Get list of UI test reports from the Carrier platform. Optionally filter by time range."
     args_schema: Type[BaseModel] = create_model(
         "GetUIReportsInput",
         report_id=(str, Field(description="UI Report id to retrieve")),

--- a/alita_sdk/tools/carrier/ui_reports_tool.py
+++ b/alita_sdk/tools/carrier/ui_reports_tool.py
@@ -199,12 +199,16 @@ class GetUITestsTool(BaseTool):
             # Extract relevant fields for cleaner output
             base_fields = {
                 "id", "name", "browser", "loops", "aggregation", "parallel_runners", 
-                "location", "entrypoint", "runner", "test_uid", "job_type"
+                "location", "entrypoint", "runner", "job_type"
             }
             
             result_tests = []
             for test in filtered_tests:
                 trimmed = {k: test[k] for k in base_fields if k in test}
+                
+                # Add test_uid separately with a clear label to avoid confusion with id
+                if "test_uid" in test:
+                    trimmed["test_uid"] = test["test_uid"]
                 
                 # Include test parameters if available
                 if "test_parameters" in test:

--- a/alita_sdk/tools/carrier/update_ui_test_schedule_tool.py
+++ b/alita_sdk/tools/carrier/update_ui_test_schedule_tool.py
@@ -1,0 +1,278 @@
+import logging
+import json
+import traceback
+import re
+from typing import Type
+from langchain_core.tools import BaseTool, ToolException
+from pydantic.fields import Field
+from pydantic import create_model, BaseModel
+from .api_wrapper import CarrierAPIWrapper
+
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateUITestScheduleTool(BaseTool):
+    api_wrapper: CarrierAPIWrapper = Field(..., description="Carrier API Wrapper instance")
+    name: str = "update_ui_test_schedule"
+    description: str = ("Update UI test schedule on the Carrier platform. Use this tool when user wants to update, modify, or change a UI test schedule. "
+                        "Provide test_id, schedule_name, and cron_timer, or leave empty to see available tests.")
+    args_schema: Type[BaseModel] = create_model(
+        "UpdateUITestScheduleInput",
+        test_id=(str, Field(default="", description="Test ID to update schedule for")),
+        schedule_name=(str, Field(default="", description="Name for the new schedule")),
+        cron_timer=(str, Field(default="", description="Cron expression for schedule timing (e.g., '0 2 * * *')")),
+    )
+    
+    def _run(self, test_id: str = "", schedule_name: str = "", cron_timer: str = ""):
+        try:
+            # Check if no parameters provided - show available tests
+            if (not test_id or test_id.strip() == "") and (not schedule_name or schedule_name.strip() == "") and (not cron_timer or cron_timer.strip() == ""):
+                return self._show_available_tests_and_instructions()
+            
+            # Check if test_id is missing but other params provided
+            if (not test_id or test_id.strip() == ""):
+                return self._show_missing_test_id_message()
+            
+            # Check if schedule_name or cron_timer is missing
+            if (not schedule_name or schedule_name.strip() == "") or (not cron_timer or cron_timer.strip() == ""):
+                return self._show_missing_parameters_message(test_id, schedule_name, cron_timer)
+            
+            # Validate cron timer format
+            if not self._validate_cron_timer(cron_timer):
+                return self._show_invalid_cron_message(cron_timer)
+            
+            # Get UI tests list to verify test exists
+            ui_tests = self.api_wrapper.get_ui_tests_list()
+            test_data = None
+            test_id_int = None
+            
+            # Try to find test by ID
+            if test_id.isdigit():
+                test_id_int = int(test_id)
+                for test in ui_tests:
+                    if test.get("id") == test_id_int:
+                        test_data = test
+                        break
+            
+            if not test_data:
+                available_tests = []
+                for test in ui_tests:
+                    available_tests.append(f"ID: {test.get('id')}, Name: {test.get('name')}")
+                
+                return f"❌ **Test not found for ID: {test_id}**\n\n**Available UI tests:**\n" + "\n".join([f"- {test}" for test in available_tests])
+            
+            # Get detailed test configuration
+            test_details = self.api_wrapper.get_ui_test_details(str(test_id_int))
+            
+            if not test_details:
+                return f"❌ **Could not retrieve test details for test ID {test_id_int}.**"
+            
+            # Parse and update the test configuration
+            updated_config = self._parse_and_update_test_data(test_details, schedule_name, cron_timer)
+            
+            # Execute the PUT request to update the test
+            result = self.api_wrapper.update_ui_test(str(test_id_int), updated_config)
+            
+            return self._format_success_message(test_data.get('name', 'Unknown'), test_id_int, schedule_name, cron_timer)
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error updating UI test schedule: {stacktrace}")
+            raise ToolException(stacktrace)
+    
+    def _show_available_tests_and_instructions(self):
+        """Show available tests and instructions when no parameters provided."""
+        try:
+            ui_tests = self.api_wrapper.get_ui_tests_list()
+            
+            if not ui_tests:
+                return "❌ **No UI tests found.**"
+            
+            message = ["# 📋 Update UI Test Schedule\n"]
+            message.append("## Available UI Tests:")
+            
+            for test in ui_tests:
+                message.append(f"- **ID: {test.get('id')}**, Name: `{test.get('name')}`, Runner: `{test.get('runner')}`")
+            
+            message.append("\n## 📝 Instructions:")
+            message.append("For updating UI test schedule, please provide me:")
+            message.append("- **`test_id`** - The ID of the test you want to update")
+            message.append("- **`schedule_name`** - A name for your new schedule")
+            message.append("- **`cron_timer`** - Cron expression for timing (e.g., `0 2 * * *` for daily at 2 AM)")
+            
+            message.append("\n## 💡 Example:")
+            message.append("```")
+            message.append("test_id: 42")
+            message.append("schedule_name: Daily Morning Test")
+            message.append("cron_timer: 0 2 * * *")
+            message.append("```")
+            
+            return "\n".join(message)
+            
+        except Exception:
+            stacktrace = traceback.format_exc()
+            logger.error(f"Error fetching UI tests list: {stacktrace}")
+            raise ToolException(stacktrace)
+    
+    def _show_missing_test_id_message(self):
+        """Show message when test_id is missing."""
+        return """# ❌ Missing Test ID
+
+**For updating UI test schedule, please provide me:**
+- **`test_id`** - The ID of the test you want to update  
+- **`schedule_name`** - A name for your new schedule
+- **`cron_timer`** - Cron expression for timing
+
+Use the tool without parameters to see available tests."""
+    
+    def _show_missing_parameters_message(self, test_id: str, schedule_name: str, cron_timer: str):
+        """Show message when some parameters are missing."""
+        missing = []
+        if not schedule_name or schedule_name.strip() == "":
+            missing.append("**`schedule_name`**")
+        if not cron_timer or cron_timer.strip() == "":
+            missing.append("**`cron_timer`**")
+        
+        message = [f"# ❌ Missing Parameters for Test ID: {test_id}\n"]
+        message.append("**Missing parameters:**")
+        for param in missing:
+            message.append(f"- {param}")
+        
+        message.append("\n**For updating UI test schedule, please provide:**")
+        message.append("- **`test_id`** ✅ (provided)")
+        message.append("- **`schedule_name`** - A name for your new schedule")
+        message.append("- **`cron_timer`** - Cron expression for timing (e.g., `0 2 * * *`)")
+        
+        return "\n".join(message)
+    
+    def _validate_cron_timer(self, cron_timer: str) -> bool:
+        """Validate cron timer format."""
+        # Basic cron validation - should have 5 parts separated by spaces
+        parts = cron_timer.strip().split()
+        if len(parts) != 5:
+            return False
+        
+        # Each part should contain only digits, *, /, -, or ,
+        cron_pattern = re.compile(r'^[0-9*,/-]+$')
+        return all(cron_pattern.match(part) for part in parts)
+    
+    def _show_invalid_cron_message(self, cron_timer: str):
+        """Show message for invalid cron timer."""
+        return f"""# ❌ Invalid Cron Timer Format
+
+**Provided:** `{cron_timer}`
+
+**Cron format should be:** `minute hour day month weekday`
+
+## Valid Examples:
+- `0 2 * * *` - Daily at 2:00 AM
+- `30 14 * * 1` - Every Monday at 2:30 PM  
+- `0 */6 * * *` - Every 6 hours
+- `15 10 1 * *` - First day of every month at 10:15 AM
+- `0 9 * * 1-5` - Weekdays at 9:00 AM
+
+## Format Rules:
+- **Minute:** 0-59
+- **Hour:** 0-23
+- **Day:** 1-31
+- **Month:** 1-12
+- **Weekday:** 0-7 (0 and 7 are Sunday)
+- Use **`*`** for "any value"
+- Use **`,`** for multiple values
+- Use **`-`** for ranges
+- Use **`/`** for step values"""
+    
+    def _parse_and_update_test_data(self, get_data: dict, schedule_name: str, cron_timer: str) -> dict:
+        """Parse GET response data and transform it into the required format for PUT request."""
+        
+        # Extract environment and test type from test parameters
+        env_type = ""
+        test_type = ""
+        for param in get_data.get("test_parameters", []):
+            if param.get("name") == "env_type":
+                env_type = param.get("default", "")
+            elif param.get("name") == "test_type":
+                test_type = param.get("default", "")
+        
+        # Construct common_params from GET data
+        common_params = {
+            "aggregation": get_data.get("aggregation", "max"),
+            "cc_env_vars": get_data.get("cc_env_vars", {}),
+            "entrypoint": get_data.get("entrypoint", ""),
+            "env_type": env_type,
+            "env_vars": get_data.get("env_vars", {}),
+            "location": get_data.get("location", ""),
+            "loops": get_data.get("loops", 1),
+            "name": get_data.get("name", ""),
+            "parallel_runners": get_data.get("parallel_runners", 1),
+            "runner": get_data.get("runner", ""),
+            "source": get_data.get("source", {}),
+            "test_type": test_type
+        }
+        
+        # Extract only required integrations (reporters and system)
+        integrations = {
+            "reporters": get_data.get("integrations", {}).get("reporters", {}),
+            "system": get_data.get("integrations", {}).get("system", {})
+        }
+        
+        # Process existing schedules and add the new one
+        schedules = []
+        
+        # Keep existing schedules
+        for schedule in get_data.get("schedules", []):
+            existing_schedule = {
+                "active": schedule.get("active", False),
+                "cron": schedule.get("cron", ""),
+                "cron_radio": "custom",
+                "errors": {},
+                "id": schedule.get("id"),
+                "name": schedule.get("name", ""),
+                "project_id": schedule.get("project_id"),
+                "rpc_kwargs": schedule.get("rpc_kwargs"),
+                "test_id": schedule.get("test_id"),
+                "test_params": schedule.get("test_params", [])
+            }
+            schedules.append(existing_schedule)
+        
+        # Add the new schedule
+        new_schedule = {
+            "active": True,
+            "cron": cron_timer,
+            "cron_radio": "custom",
+            "errors": {},
+            "id": None,  # New schedule, no ID yet
+            "name": schedule_name,
+            "test_params": []
+        }
+        schedules.append(new_schedule)
+        
+        # Assemble the final PUT request data
+        put_data = {
+            "common_params": common_params,
+            "integrations": integrations,
+            "run_test": False,
+            "schedules": schedules,
+            "test_parameters": []  # Empty as required in PUT request
+        }
+        
+        return put_data
+    
+    def _format_success_message(self, test_name: str, test_id: int, schedule_name: str, cron_timer: str) -> str:
+        """Format success message in markdown."""
+        return f"""# ✅ UI Test Schedule Updated Successfully!
+
+## Test Information:
+- **Test Name:** `{test_name}`
+- **Test ID:** `{test_id}`
+
+## New Schedule Added:
+- **Schedule Name:** `{schedule_name}`
+- **Cron Timer:** `{cron_timer}`
+- **Status:** Active ✅
+
+## 🎯 What happens next:
+The test will now run automatically according to the specified schedule. You can view and manage schedules in the Carrier platform UI.
+
+**Schedule will execute:** Based on cron expression `{cron_timer}`"""


### PR DESCRIPTION
# UI Test Carrier Toolkit
In this PR I've added new Carrier tools for UI tests

## Create a New UI Test

- ✅ Prompt the user to provide default fields (e.g., `name`, `test_type`, `env_type`)
- ✅ Ask the user to select a test runner (Sitespeed or Lighthouse) and specify the runner version
- ✅ Collect the test source details from the user
- ✅ Request the test entry point from the user
- Gather information about test integrations

## Run a UI Test

- ✅ Allow users to execute a test by specifying its ID or name
- ✅ Ask the user if default parameters should be overridden for this test run (Custom CMD, loops, etc.)

## Run a Test in Different Locations

- ✅ Ask the user to specify the location(s) where the test should be executed
- ✅ Request the number of load generators and their configuration details

## Filter Reports by Time

- ✅ Enable users to retrieve reports for a specific time range (e.g., reports from the last 5 days)

## Generate Excel Reports

- ✅ Provide the ability to generate an Excel report based on a `report_id`

## Download Standard Reports

- ✅ Allow users to download standard Sitespeed or Lighthouse reports using a `report_id`

## Filter Reports and Tests by Name

- ✅ Enable users to filter reports and tests based on their names

## Cancel a Test

- ✅ Provide the ability to cancel a running test

## Schedule a Test

- ✅ Allow users to schedule tests to run at a specific time or interval

