### PR TITLE
GitLab & GitLab Org – List Branches in Repo Enhancements

### DIFF
--- a/alita_sdk/tools/gitlab/__init__.py
+++ b/alita_sdk/tools/gitlab/__init__.py
@@ -85,13 +85,14 @@ class AlitaGitlabToolkit(BaseToolkit):
             if selected_tools:
                 if tool["name"] not in selected_tools:
                     continue
+
             tools.append(BaseAction(
                 api_wrapper=gitlab_api_wrapper,
                 name=prefix + tool["name"],
-                description=tool["description"] + "\nrepo: " + gitlab_api_wrapper.repository,
+                description=tool["description"] +  f"\nrepo: {gitlab_api_wrapper.repository}",
                 args_schema=tool["args_schema"]
             ))
         return cls(tools=tools)
 
-    def get_tools(self):
+    def get_tools(self)-> List[BaseTool]:
         return self.tools

--- a/alita_sdk/tools/gitlab/api_wrapper.py
+++ b/alita_sdk/tools/gitlab/api_wrapper.py
@@ -1,6 +1,7 @@
 # api_wrapper.py
 from typing import Any, Dict, List, Optional
-
+import fnmatch
+from alita_sdk.tools.elitea_base import BaseVectorStoreToolApiWrapper, extend_with_vector_tools
 from alita_sdk.tools.elitea_base import BaseCodeToolApiWrapper
 from pydantic import create_model, Field, model_validator, SecretStr, PrivateAttr
 
@@ -53,7 +54,11 @@ CreateBranchModel = create_model(
 )
 ListBranchesInRepoModel = create_model(
     "ListBranchesInRepoModel",
+    limit=(Optional[int], Field(None, description="Maximum number of branches to return. If not provided, all branches will be returned.")),
+    branch_wildcard=(Optional[str], Field(default=None, description="Wildcard pattern to filter branches by name. If not provided, all branches will be returned."))
+
 )
+
 ListFilesModel = create_model(
     "ListFilesModel",
     path=(Optional[str], Field(description="The path to list files from")),
@@ -93,7 +98,7 @@ GetCommitsModel = create_model(
     author=(Optional[str], Field(description="Author name", default=None)),
 )
 
-class GitLabAPIWrapper(BaseCodeToolApiWrapper):
+class GitLabAPIWrapper(BaseVectorStoreToolApiWrapper):
     url: str
     repository: str
     private_token: SecretStr
@@ -142,9 +147,30 @@ class GitLabAPIWrapper(BaseCodeToolApiWrapper):
         self._repo_instance.default_branch = branch_name
         return f"Active branch set to {branch_name}"
 
-    def list_branches_in_repo(self) -> List[str]:
-        branches = self._repo_instance.branches.list()
-        return [branch.name for branch in branches]
+    def list_branches_in_repo(self, limit: Optional[int] = None, branch_wildcard: Optional[str] = None) -> List[str]:
+        """
+        Lists branches in the repository with optional limit and wildcard filtering.
+
+        Parameters:
+            limit (Optional[int]): Maximum number of branches to return
+            branch_wildcard (Optional[str]): Wildcard pattern to filter branches (e.g., '*dev')
+
+        Returns:
+            List[str]: List containing names of branches
+        """
+        try:
+            branches = self._repo_instance.branches.list(get_all=True)
+            
+            if branch_wildcard:
+                branches = [branch for branch in branches if fnmatch.fnmatch(branch.name, branch_wildcard)]
+            
+            if limit is not None:
+                branches = branches[:limit]
+            
+            branch_names = [branch.name for branch in branches]
+            return branch_names
+        except Exception as e:
+            return f"Failed to list branches: {str(e)}"
 
     def list_files(self, path: str = None, recursive: bool = True, branch: str = None) -> List[str]:
         branch = branch if branch else self._active_branch
@@ -404,84 +430,85 @@ class GitLabAPIWrapper(BaseCodeToolApiWrapper):
             for commit in commits
         ]
 
+    @extend_with_vector_tools
     def get_available_tools(self):
         return [
             {
                 "name": "create_branch",
                 "ref": self.create_branch,
-                "description": self.create_branch.__doc__,
+                "description": self.create_branch.__doc__ or "Create a new branch in the repository.",
                 "args_schema": CreateBranchModel,
             },
             {
                 "name": "list_branches_in_repo",
                 "ref": self.list_branches_in_repo,
-                "description": self.list_branches_in_repo.__doc__,
+                "description": self.list_branches_in_repo.__doc__ or "List branches in the repository with optional limit and wildcard filtering.",
                 "args_schema": ListBranchesInRepoModel,
             },
             {
                 "name": "list_files",
                 "ref": self.list_files,
-                "description": self.list_files.__doc__,
+                "description": self.list_files.__doc__ or "List files in the repository with optional path, recursive search, and branch.",
                 "args_schema": ListFilesModel,
             },
             {
                 "name": "list_folders",
                 "ref": self.list_folders,
-                "description": self.list_folders.__doc__,
+                "description": self.list_folders.__doc__ or "List folders in the repository with optional path, recursive search, and branch.",
                 "args_schema": ListFoldersModel,
             },
             {
                 "name": "get_issues",
                 "ref": self.get_issues,
-                "description": self.get_issues.__doc__,
+                "description": self.get_issues.__doc__ or "Get all open issues in the repository.",
                 "args_schema": GetIssuesModel,
             },
             {
                 "name": "get_issue",
                 "ref": self.get_issue,
-                "description": self.get_issue.__doc__,
+                "description": self.get_issue.__doc__ or "Get details of a specific issue by its number.",
                 "args_schema": GetIssueModel,
             },
             {
                 "name": "create_pull_request",
                 "ref": self.create_pull_request,
-                "description": self.create_pull_request.__doc__,
+                "description": self.create_pull_request.__doc__ or "Create a pull request (merge request) in the repository.",
                 "args_schema": CreatePullRequestModel,
             },
             {
                 "name": "comment_on_issue",
                 "ref": self.comment_on_issue,
-                "description": self.comment_on_issue.__doc__,
+                "description": self.comment_on_issue.__doc__ or "Comment on an issue in the repository.",
                 "args_schema": CommentOnIssueModel,
             },
             {
                 "name": "create_file",
                 "ref": self.create_file,
-                "description": self.create_file.__doc__,
+                "description": self.create_file.__doc__ or "Create a new file in the repository.",
                 "args_schema": CreateFileModel,
             },
             {
                 "name": "read_file",
                 "ref": self.read_file,
-                "description": self.read_file.__doc__,
+                "description": self.read_file.__doc__ or "Read the contents of a file in the repository.",
                 "args_schema": ReadFileModel,
             },
             {
                 "name": "update_file",
                 "ref": self.update_file,
-                "description": self.update_file.__doc__,
+                "description": self.update_file.__doc__ or "Update the contents of a file in the repository.",
                 "args_schema": UpdateFileModel,
             },
             {
                 "name": "append_file",
                 "ref": self.append_file,
-                "description": self.append_file.__doc__,
+                "description": self.append_file.__doc__ or "Append content to a file in the repository.",
                 "args_schema": AppendFileModel,
             },
             {
                 "name": "delete_file",
                 "ref": self.delete_file,
-                "description": self.delete_file.__doc__,
+                "description": self.delete_file.__doc__ or "Delete a file from the repository.",
                 "args_schema": DeleteFileModel,
             },
             {
@@ -507,5 +534,5 @@ class GitLabAPIWrapper(BaseCodeToolApiWrapper):
                 "ref": self.get_commits,
                 "description": "Retrieve a list of commits from the repository.",
                 "args_schema": GetCommitsModel,
-            },
+            }
         ] + self._get_vector_search_tools()

--- a/alita_sdk/tools/gitlab/api_wrapper.py
+++ b/alita_sdk/tools/gitlab/api_wrapper.py
@@ -1,7 +1,7 @@
 # api_wrapper.py
 from typing import Any, Dict, List, Optional
 import fnmatch
-from alita_sdk.tools.elitea_base import BaseVectorStoreToolApiWrapper, extend_with_vector_tools
+from alita_sdk.tools.elitea_base import extend_with_vector_tools
 from alita_sdk.tools.elitea_base import BaseCodeToolApiWrapper
 from pydantic import create_model, Field, model_validator, SecretStr, PrivateAttr
 
@@ -54,7 +54,7 @@ CreateBranchModel = create_model(
 )
 ListBranchesInRepoModel = create_model(
     "ListBranchesInRepoModel",
-    limit=(Optional[int], Field(None, description="Maximum number of branches to return. If not provided, all branches will be returned.")),
+    limit=(Optional[int], Field(default=20, description="Maximum number of branches to return. If not provided, all branches will be returned.")),
     branch_wildcard=(Optional[str], Field(default=None, description="Wildcard pattern to filter branches by name. If not provided, all branches will be returned."))
 
 )
@@ -98,7 +98,7 @@ GetCommitsModel = create_model(
     author=(Optional[str], Field(description="Author name", default=None)),
 )
 
-class GitLabAPIWrapper(BaseVectorStoreToolApiWrapper):
+class GitLabAPIWrapper(BaseCodeToolApiWrapper):
     url: str
     repository: str
     private_token: SecretStr
@@ -147,7 +147,7 @@ class GitLabAPIWrapper(BaseVectorStoreToolApiWrapper):
         self._repo_instance.default_branch = branch_name
         return f"Active branch set to {branch_name}"
 
-    def list_branches_in_repo(self, limit: Optional[int] = None, branch_wildcard: Optional[str] = None) -> List[str]:
+    def list_branches_in_repo(self, limit: Optional[int] = 20, branch_wildcard: Optional[str] = None) -> List[str]:
         """
         Lists branches in the repository with optional limit and wildcard filtering.
 

--- a/alita_sdk/tools/gitlab_org/api_wrapper.py
+++ b/alita_sdk/tools/gitlab_org/api_wrapper.py
@@ -24,7 +24,7 @@ GitLabCreateBranch = create_model(
 GitLabListBranches = create_model(
     "GitLabListBranchesModel",
     repository=(Optional[str], Field(description="Name of the repository", default=None)),
-    limit=(Optional[int], Field(description="Maximum number of branches to return. If not provided, all branches will be returned.", default=None)),
+    limit=(Optional[int], Field(description="Maximum number of branches to return. If not provided, all branches will be returned.", default=20)),
     branch_wildcard=(Optional[str], Field(description="Wildcard pattern to filter branches by name. If not provided, all branches will be returned.", default=None))
 )
 
@@ -212,7 +212,7 @@ class GitLabWorkspaceAPIWrapper(BaseToolApiWrapper):
         self._active_branch = branch
         return f"Active branch set to {branch}"
 
-    def list_branches_in_repo(self, repository: Optional[str] = None, limit: Optional[int] = None, branch_wildcard: Optional[str] = None) -> List[str]:
+    def list_branches_in_repo(self, repository: Optional[str] = None, limit: Optional[int] = 20, branch_wildcard: Optional[str] = None) -> List[str]:
         """
         Lists branches in the repository with optional limit and wildcard filtering.
 


### PR DESCRIPTION
**Summary:**
This PR enhances the list_branches_in_repo functionality for both the GitLab and GitLab Org toolkits.

**Key Changes:**
1. Updated the list_branches_in_repo method to support both limit and optional branch_wildcard parameters.
  - The method now returns all branches  up to the specified number of limit.
  - Improved wildcard filtering for branch names using the branch_wildcard parameter.

**Impact:**
These changes make branch listing more flexible and user-friendly, supporting both full and filtered results.