### PR TITLE
Fix List Collections Tool Output

### DIFF
--- a/alita_sdk/runtime/tools/vectorstore.py
+++ b/alita_sdk/runtime/tools/vectorstore.py
@@ -212,10 +212,27 @@ class VectorStoreWrapper(BaseToolApiWrapper):
         """Get all indexed document IDs from vectorstore"""
         return self.vector_adapter.get_indexed_ids(self, collection_suffix)
 
-    def list_collections(self) -> List[str]:
-        """List all collections in the vectorstore."""
-
-        return self.vector_adapter.list_collections(self)
+    def list_collections(self) -> Any:
+        """List all collections in the vectorstore.
+        Returns a list of collection names, or if no collections exist,
+        returns a dict with an empty list and a message."""
+        raw = self.vector_adapter.list_collections(self)
+        # Normalize raw result to a list of names
+        if not raw:
+            # No collections found
+            return {"collections": [], "message": "No indexed collections"}
+        if isinstance(raw, str):
+            # e.g., Chroma adapter returns comma-separated string
+            cols = [c for c in raw.split(',') if c]
+        else:
+            try:
+                cols = list(raw)
+            except Exception:
+                # Unexpected type, return raw directly
+                return raw
+        if not cols:
+            return {"collections": [], "message": "No indexed collections"}
+        return cols
 
     def _clean_collection(self, collection_suffix: str = ''):
         """
@@ -765,4 +782,3 @@ class VectorStoreWrapper(BaseToolApiWrapper):
                 "args_schema": StepBackSearchDocumentsModel
             }
         ]
-


### PR DESCRIPTION
Updated the List Collections tool to return an empty JSON payload (e.g., `[]` or `{}`) with a clear message like "No indexed collections" when no collections exist. This resolves the misleading generic success message issue.

Closes #1787.