### PR TITLE
Add Chunking Tool and Config Support

### DIFF
--- a/alita_sdk/tools/base_indexer_toolkit.py
+++ b/alita_sdk/tools/base_indexer_toolkit.py
@@ -91,6 +91,7 @@ BaseIndexDataParams = create_model(
                          description="Optional step size for progress reporting during indexing")),
     clean_index=(Optional[bool], Field(default=False,
                        description="Optional flag to enforce clean existing index before indexing new data")),
+    chunking_tool=(Optional[str], Field(description="Name of chunking tool to apply during indexing", default=None)),
     chunking_config=(Optional[dict], Field(description="Chunking tool configuration", default_factory=dict)),
 )
 
@@ -421,4 +422,3 @@ class BaseIndexerToolkit(VectorStoreWrapperBase):
                 "description": self.list_collections.__doc__,
                 "args_schema": create_model("ListCollectionsParams")  # No parameters
             },
-        ]

--- a/docs/indexer/index_data.md
+++ b/docs/indexer/index_data.md
@@ -72,7 +72,10 @@ Corner case: Handles empty document lists and ensures atomicity of the save oper
 - `clean_index` (`Optional[bool]`):  
   Optional flag to enforce cleaning the existing index before indexing new data (default: `False`).
 
-- `chunking_config` (`Optional[dict]`):  
+-- `chunking_tool` (`Optional[str]`):  
+   Name of the chunking tool to apply during indexing (default: `None`).  
+   Available tools include: `code_parser`, `statistical`, `markdown`, `proposal`, `json`.
+-- `chunking_config` (`Optional[dict]`):  
   Chunking tool configuration (default: empty dict).   
   Example: {".pdf": {"mode": "page", "chunk_size": 1000}, ".docx": {"mode": "paragraph"}, ".md": {"chunk_size": 333}}
 


### PR DESCRIPTION
This PR addresses the issue of missing Chunking Tool and Chunking Config support for the 'Index data' feature across multiple toolkits.

### Changes:
- Added both Chunking Tool and Config support for:
  - ADO Repos
  - BitBucket
  - GitHub
  - GitLab
- Added only Chunking Tool support for:
  - Sharepoint
  - ADO Board
  - TestRail
  - Artifact
  - Figma

### Additional Updates:
- Updated documentation to reflect the changes.
- Performed integration testing to ensure compatibility.

### Closes:
This PR closes #1880.