### PR TITLE
Use MessagesPlaceholder for the input

### DIFF
--- a/alita_sdk/runtime/langchain/assistant.py
+++ b/alita_sdk/runtime/langchain/assistant.py
@@ -93,7 +93,7 @@ class Assistant:
             elif app_type == "xml":
                 messages.append(HumanMessage(XML_ADDON))
             elif app_type in ['openai', 'dial']:
-                messages.append(HumanMessage("{{input}}"))
+                messages.append(MessagesPlaceholder("input"))
             messages.append(MessagesPlaceholder("agent_scratchpad"))
             variables = {}
             input_variables = []


### PR DESCRIPTION
We can expand multimodal non-str input correctly, otherwise a list of dicts will be treated as str